### PR TITLE
chore(🤖): Bump `NVIDIA/NeMo` to `f652c58...` (2025-06-03)

### DIFF
--- a/docker/manifest.json
+++ b/docker/manifest.json
@@ -1,16 +1,16 @@
 {
-    "vcs-dependencies": {
-        "transformer_engine": {
-            "repo": "https://github.com/NVIDIA/TransformerEngine",
-            "ref": "bee4649c15a79ffcb9689ca7c0c963f5febaa28a"
-        },
-        "megatron-lm": {
-            "repo": "https://github.com/NVIDIA/Megatron-LM",
-            "ref": "9eebd5173cbd6dea5e6a324d418b669ac000989e"
-        },
-        "trt-llm": {
-            "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",
-            "ref": "v0.18.0"
-        }
+  "vcs-dependencies": {
+    "transformer_engine": {
+      "repo": "https://github.com/NVIDIA/TransformerEngine",
+      "ref": "bee4649c15a79ffcb9689ca7c0c963f5febaa28a"
+    },
+    "megatron-lm": {
+      "repo": "https://github.com/NVIDIA/Megatron-LM",
+      "ref": "f652c583c85a3b909725d010cb15a8a040403e92"
+    },
+    "trt-llm": {
+      "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",
+      "ref": "v0.18.0"
     }
+  }
 }


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/NeMo` in `docker/manifest.json` to `f652c583c85a3b909725d010cb15a8a040403e92`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.