### PR TITLE
chore(🤖): Bump `NVIDIA/NeMo` to `f652c58...` (2025-06-03)

### DIFF
--- a/docker/manifest.json
+++ b/docker/manifest.json
@@ -10,7 +10,7 @@
     },
     "nemo": {
       "repo": "https://github.com/NVIDIA/NeMo.git",
-      "ref": "main"
+      "ref": "f652c583c85a3b909725d010cb15a8a040403e92"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/NeMo` in `docker/manifest.json` to `f652c583c85a3b909725d010cb15a8a040403e92`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.