### PR TITLE
chore(🤖): Bump `NVIDIA/NeMo` to `97b9fed...` (2025-06-03)

### DIFF
--- a/docker/manifest.json
+++ b/docker/manifest.json
@@ -10,7 +10,7 @@
     },
     "nemo": {
       "repo": "https://github.com/NVIDIA/NeMo.git",
-      "ref": "main"
+      "ref": "97b9fed8e0f1b1613040c329b159ea865c537c81"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/NeMo` in `docker/manifest.json` to `97b9fed8e0f1b1613040c329b159ea865c537c81`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.