### PR TITLE
chore(🤖): Bump `NVIDIA/NeMo` to `8398c34...` (2025-06-03)

### DIFF
--- a/docker/manifest.json
+++ b/docker/manifest.json
@@ -10,7 +10,7 @@
     },
     "nemo": {
       "repo": "https://github.com/NVIDIA/NeMo.git",
-      "ref": "main"
+      "ref": "8398c345ea11a12c6b7cce99f4104e1cfd4be963"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/NeMo` in `docker/manifest.json` to `8398c345ea11a12c6b7cce99f4104e1cfd4be963`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.