### PR TITLE
ci: Add build-test-publish wheel workflow

### DIFF
--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -27,7 +27,7 @@ defaults:
 
 jobs:
   build-test-publish-wheel:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@ko3n1g/feat/no-push
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.38.0
     with:
       dry-run: true
       python-package: nemo_export_deploy_common


### PR DESCRIPTION
Tests that building and installing a wheel still works
