### PR TITLE
ci: Skip for deployment jobs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -23,5 +23,4 @@ on:
 
 jobs:
   build-docs:
-    needs: [pre-flight]
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.48.0

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,5 +22,26 @@ on:
       - "deploy-release/*"
 
 jobs:
+  pre-flight:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@ko3n1g/feat/detect-deployment-workflow
+
   build-docs:
+    needs: [pre-flight]
+    if: |
+      !(needs.pre-flight.outputs.docs_only == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.48.0
+
+  build-docs-summary:
+    needs: [pre-flight, build-docs]
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+        || success()
+      )
+      && !cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Result
+        run: echo Build docs successful

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   pre-flight:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@ko3n1g/feat/detect-deployment-workflow
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.53.0
 
   build-docs:
     needs: [pre-flight]

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -19,7 +19,9 @@ on:
     branches:
       - main
       - "pull-request/[0-9]+"
+      - "deploy-release/*"
 
 jobs:
   build-docs:
+    needs: [pre-flight]
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.48.0

--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -48,3 +48,17 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
       GH_TOKEN: ${{ secrets.PAT }}
+
+  build-test-publish-wheel-summary:
+    needs: [pre-flight, build-test-publish-wheel]
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+        || success()
+      )
+      && !cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Result
+        run: echo Build test publish wheel successful

--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -28,7 +28,7 @@ defaults:
 
 jobs:
   pre-flight:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@ko3n1g/feat/detect-deployment-workflow
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.53.0
 
   build-test-publish-wheel:
     needs: [pre-flight]

--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -27,7 +27,14 @@ defaults:
     shell: bash -x -e -u -o pipefail {0}
 
 jobs:
+  pre-flight:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@ko3n1g/feat/detect-deployment-workflow
+
   build-test-publish-wheel:
+    needs: [pre-flight]
+    if: |
+      !(needs.pre-flight.outputs.docs_only == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.38.0
     with:
       dry-run: true

--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -20,6 +20,7 @@ on:
       - main
       - "r**"
       - "pull-request/**"
+      - "deploy-release/*"
 
 defaults:
   run:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - main
       - "pull-request/[0-9]+"
+      - "deploy-release/*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name || 'main' }}-${{ github.event_name }}

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -30,10 +30,12 @@ permissions:
 
 jobs:
   pre-flight:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.45.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@ko3n1g/feat/detect-deployment-workflow
 
   linting:
     runs-on: ubuntu-latest
+    needs: [pre-flight]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,6 +58,7 @@ jobs:
     environment: test
     if: |
       !(needs.pre-flight.outputs.is_ci_workload == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true'
       || needs.pre-flight.outputs.docs_only == 'true')
     steps:
       - name: Running CI tests
@@ -245,6 +248,7 @@ jobs:
     if: |
       (
         needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
         || success()
       )
       && !cancelled()
@@ -344,14 +348,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pre-flight, Nemo_CICD_Test]
     if: |
-      needs.pre-flight.outputs.test_to_run != '[]' 
-      && needs.pre-flight.outputs.components_to_run != '[]'
-      && (
-        success() 
-        || (
-          needs.cicd-wait-in-queue.result == 'skipped'
-          && needs.pre-flight.outputs.is_ci_workload == 'true'
-        )
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+        || success()
       )
       && !cancelled()
     strategy:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -350,9 +350,9 @@ jobs:
     needs: [pre-flight, Nemo_CICD_Test]
     if: |
       (
-        needs.pre-flight.outputs.docs_only == 'true'
-        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
-        || success()
+        needs.pre-flight.outputs.docs_only == 'false'
+        && needs.pre-flight.outputs.is_deployment_workflow == 'false'
+        && success()
       )
       && !cancelled()
     strategy:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -351,7 +351,7 @@ jobs:
     if: |
       (needs.pre-flight.outputs.docs_only == 'true'
       || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-      && (success() || skipped())
+      && !failure()
       && !cancelled()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   pre-flight:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@ko3n1g/feat/detect-deployment-workflow
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.53.0
 
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -345,6 +345,19 @@ jobs:
             exit 1
           fi
 
+  coverage-placeholder:
+    needs: [pre-flight]
+    name: codecov/patch
+    if: |
+      (needs.pre-flight.outputs.docs_only == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true')
+      && success()
+      && !cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dummy placeholder
+        run: echo "noop"
+
   Coverage:
     runs-on: ubuntu-latest
     needs: [pre-flight, Nemo_CICD_Test]

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -346,7 +346,7 @@ jobs:
           fi
 
   coverage-placeholder:
-    needs: [pre-flight]
+    needs: [pre-flight, Nemo_CICD_Test]
     name: codecov/patch
     if: |
       (needs.pre-flight.outputs.docs_only == 'true'

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -36,7 +36,10 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     needs: [pre-flight]
-
+    if: |
+      !(needs.pre-flight.outputs.is_ci_workload == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+      || needs.pre-flight.outputs.docs_only == 'true')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -351,7 +351,7 @@ jobs:
     if: |
       (needs.pre-flight.outputs.docs_only == 'true'
       || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-      && success()
+      && (success() || skipped())
       && !cancelled()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -31,3 +31,17 @@ jobs:
       !(needs.pre-flight.outputs.docs_only == 'true'
       || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_copyright_check.yml@v0.2.0
+
+  copyright-check-summary:
+    needs: [pre-flight, copyright-check]
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+        || success()
+      )
+      && !cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Result
+        run: echo Copyright check successful

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -22,5 +22,12 @@ on:
       - "deploy-release/*"
 
 jobs:
+  pre-flight:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@ko3n1g/feat/detect-deployment-workflow
+
   copyright-check:
+    needs: [pre-flight]
+    if: |
+      !(needs.pre-flight.outputs.docs_only == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_copyright_check.yml@v0.2.0

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   pre-flight:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@ko3n1g/feat/detect-deployment-workflow
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.53.0
 
   copyright-check:
     needs: [pre-flight]

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -15,7 +15,11 @@
 name: Copyright check
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
+      - "pull-request/[0-9]+"
+      - "deploy-release/*"
 
 jobs:
   copyright-check:

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -22,6 +22,8 @@ on:
     branches:
       - main
       - "pull-request/[0-9]+"
+      - "deploy-release/*"
+
 env:
   UV_PROJECT_ENVIRONMENT: "./venv"
 

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -28,7 +28,14 @@ env:
   UV_PROJECT_ENVIRONMENT: "./venv"
 
 jobs:
+  pre-flight:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@ko3n1g/feat/detect-deployment-workflow
+
   pip-test-no-cuda:
+    needs: [pre-flight]
+    if: |
+      !(needs.pre-flight.outputs.docs_only == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     runs-on: ${{ matrix.arch }}
     name: Pip - Python${{ matrix.python-version }} - ${{ matrix.arch == 'ubuntu-latest' && 'AMD64/Linux' || (matrix.arch == 'ubuntu-24.04-arm' && 'ARM64/Linux' || 'ARM64/Darwin') }} - No CUDA
     strategy:
@@ -82,6 +89,10 @@ jobs:
           python-binary: ./venv/bin/python
 
   pip-test-cuda:
+    needs: [pre-flight]
+    if: |
+      !(needs.pre-flight.outputs.docs_only == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     runs-on: linux-amd64-cpu16
     name: Pip - Python${{ matrix.python-version }}${{ matrix.extra-groups != '' && format('[{0}]', matrix.extra-groups) || '' }} - AMD64/Linux - NGC CUDA
     container:
@@ -142,6 +153,10 @@ jobs:
           python-binary: ./venv/bin/python
 
   uv-test-cuda:
+    needs: [pre-flight]
+    if: |
+      !(needs.pre-flight.outputs.docs_only == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     runs-on: linux-amd64-cpu16
     name: UV - AMD64/Linux - NGC ${{ contains(matrix.image, 'cuda') && 'CUDA' || 'PyTorch' }}
     container:
@@ -198,6 +213,10 @@ jobs:
           python-binary: /opt/venv/bin/python
 
   uv-test-no-cuda:
+    needs: [pre-flight]
+    if: |
+      !(needs.pre-flight.outputs.docs_only == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     runs-on: ${{ matrix.arch }}
     name: UV - Python ${{ matrix.python-version }} - ${{ matrix.arch == 'ubuntu-latest' && 'AMD64/Linux' || 'ARM64/Darwin' }} - No CUDA
     environment: nemo-ci
@@ -256,9 +275,16 @@ jobs:
           python-binary: ./venv/bin/python
 
   install-test-summary:
-    needs: [pip-test-no-cuda, uv-test-cuda, pip-test-cuda, uv-test-no-cuda]
+    needs: [pre-flight, pip-test-no-cuda, uv-test-cuda, pip-test-cuda, uv-test-no-cuda]
     runs-on: ubuntu-latest
     name: Install test summary
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+        || success()
+      )
+      && !cancelled()
     steps:
       - name: Result
         run: echo Install check successful

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   pre-flight:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@ko3n1g/feat/detect-deployment-workflow
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.53.0
 
   pip-test-no-cuda:
     needs: [pre-flight]


### PR DESCRIPTION
Branches at `deploy-release/*` are protected. Only `nemo-automation-bot` is allowed to push to it, no-one else.

For these particular branches, we don't want to run the CI - we know that the only changes in these branches will be the version bump in `package_info.py`. However, we still need the required status checks like `Nemo_CICD_Test` to pass. We accomplish this by skipping the compute heavy jobs and to allow the required jobs to emit an exit 0 if previous jobs were intentially skipped.

All of this heavy lifting is required so that we have a branch with passing status checks that we then can merge into `main`. Without passing status checks, we wouldn't be able to merge into main since main requires passing status checks.