### PR TITLE
Add support for vLLM backend for HF model deployment with Ray

### DIFF
--- a/nemo_deploy/deploy_ray.py
+++ b/nemo_deploy/deploy_ray.py
@@ -180,7 +180,6 @@ class DeployRay:
         self,
         nemo_checkpoint: str,
         num_gpus: int = 1,
-        num_nodes: int = 1,
         tensor_model_parallel_size: int = 1,
         pipeline_model_parallel_size: int = 1,
         expert_model_parallel_size: int = 1,
@@ -206,7 +205,6 @@ class DeployRay:
         Args:
             nemo_checkpoint (str): Path to the .nemo checkpoint file.
             num_gpus (int, optional): Number of GPUs per node. Defaults to 1.
-            num_nodes (int, optional): Number of nodes for deployment. Defaults to 1.
             tensor_model_parallel_size (int, optional): Tensor model parallel size. Defaults to 1.
             pipeline_model_parallel_size (int, optional): Pipeline model parallel size. Defaults to 1.
             expert_model_parallel_size (int, optional): Expert model parallel size. Defaults to 1.

--- a/nemo_deploy/deploy_ray.py
+++ b/nemo_deploy/deploy_ray.py
@@ -27,6 +27,7 @@ try:
     from ray.serve import Application
     from nemo_deploy.nlp.megatronllm_deployable_ray import MegatronRayDeployable
     from nemo_deploy.nlp.hf_deployable_ray import HFRayDeployable
+    from nemo_export.tensorrt_llm_deployable_ray import TensorRTLLMRayDeployable
 
     from nemo_deploy.nlp.hf_deployable_ray import HFRayDeployable
     from nemo_deploy.nlp.megatronllm_deployable_ray import MegatronRayDeployable
@@ -413,6 +414,7 @@ class DeployRay:
             num_gpus_per_replica (int, optional): GPUs per model replica. Defaults to 1.
             max_ongoing_requests (int, optional): Maximum number of ongoing requests per replica. Defaults to 10.
             test_mode (bool, optional): Enable test mode. Defaults to False.
+
         Raises:
             Exception: If Ray is not installed or deployment fails.
             ValueError: If C++ runtime specific options are used with Python runtime.

--- a/nemo_deploy/deploy_ray.py
+++ b/nemo_deploy/deploy_ray.py
@@ -24,10 +24,6 @@ from nemo_export_deploy_common.import_utils import MISSING_RAY_MSG, UnavailableE
 try:
     import ray
     from ray import serve
-    from ray.serve import Application
-    from nemo_deploy.nlp.megatronllm_deployable_ray import MegatronRayDeployable
-    from nemo_deploy.nlp.hf_deployable_ray import HFRayDeployable
-    from nemo_export.tensorrt_llm_deployable_ray import TensorRTLLMRayDeployable
 
     from nemo_deploy.nlp.hf_deployable_ray import HFRayDeployable
     from nemo_deploy.nlp.megatronllm_deployable_ray import MegatronRayDeployable
@@ -50,12 +46,6 @@ LOGGER = logging.getLogger("NeMo")
 def get_available_cpus():
     """Get the total number of available CPUs in the system."""
     return multiprocessing.cpu_count()
-
-
-def get_available_cpus():
-    """Get the total number of available CPUs in the system."""
-    return multiprocessing.cpu_count()
-
 
 class DeployRay:
     """A class for managing Ray deployment and serving of models.
@@ -325,7 +315,6 @@ class DeployRay:
             use_vllm_backend (bool, optional): Whether to use vLLM backend for deployment. If True, exports the HF ckpt
             to vLLM format and uses vLLM backend for inference. Defaults to False.
             test_mode (bool, optional): Enable test mode. Defaults to False.
-
         Raises:
             Exception: If Ray is not installed or deployment fails.
         """
@@ -418,7 +407,6 @@ class DeployRay:
             num_gpus_per_replica (int, optional): GPUs per model replica. Defaults to 1.
             max_ongoing_requests (int, optional): Maximum number of ongoing requests per replica. Defaults to 10.
             test_mode (bool, optional): Enable test mode. Defaults to False.
-
         Raises:
             Exception: If Ray is not installed or deployment fails.
             ValueError: If C++ runtime specific options are used with Python runtime.

--- a/nemo_deploy/deploy_ray.py
+++ b/nemo_deploy/deploy_ray.py
@@ -43,9 +43,11 @@ except (ImportError, ModuleNotFoundError):
 
 LOGGER = logging.getLogger("NeMo")
 
+
 def get_available_cpus():
     """Get the total number of available CPUs in the system."""
     return multiprocessing.cpu_count()
+
 
 class DeployRay:
     """A class for managing Ray deployment and serving of models.

--- a/nemo_deploy/deploy_ray.py
+++ b/nemo_deploy/deploy_ray.py
@@ -299,6 +299,7 @@ class DeployRay:
         num_cpus_per_replica: float = 8,
         num_gpus_per_replica: int = 1,
         max_ongoing_requests: int = 10,
+        use_vllm_backend: bool = False,
         test_mode: bool = False,
     ):
         """Deploy a Hugging Face model using Ray Serve.
@@ -321,6 +322,8 @@ class DeployRay:
             num_cpus_per_replica (float, optional): CPUs per model replica. Defaults to 8.
             num_gpus_per_replica (int, optional): GPUs per model replica. Defaults to 1.
             max_ongoing_requests (int, optional): Maximum number of ongoing requests per replica. Defaults to 10.
+            use_vllm_backend (bool, optional): Whether to use vLLM backend for deployment. If True, exports the HF ckpt
+            to vLLM format and uses vLLM backend for inference. Defaults to False.
             test_mode (bool, optional): Enable test mode. Defaults to False.
 
         Raises:
@@ -356,6 +359,7 @@ class DeployRay:
                 device_map=device_map,
                 max_memory=max_memory,
                 model_id=model_id,
+                use_vllm_backend=use_vllm_backend,
             )
 
             # Deploy the model

--- a/nemo_deploy/deploy_ray.py
+++ b/nemo_deploy/deploy_ray.py
@@ -25,6 +25,8 @@ try:
     import ray
     from ray import serve
     from ray.serve import Application
+    from nemo_deploy.nlp.megatronllm_deployable_ray import MegatronRayDeployable
+    from nemo_deploy.nlp.hf_deployable_ray import HFRayDeployable
 
     from nemo_deploy.nlp.hf_deployable_ray import HFRayDeployable
     from nemo_deploy.nlp.megatronllm_deployable_ray import MegatronRayDeployable
@@ -43,6 +45,10 @@ except (ImportError, ModuleNotFoundError):
     HAVE_RAY = False
 
 LOGGER = logging.getLogger("NeMo")
+
+def get_available_cpus():
+    """Get the total number of available CPUs in the system."""
+    return multiprocessing.cpu_count()
 
 
 def get_available_cpus():
@@ -174,6 +180,7 @@ class DeployRay:
         self,
         nemo_checkpoint: str,
         num_gpus: int = 1,
+        num_nodes: int = 1,
         tensor_model_parallel_size: int = 1,
         pipeline_model_parallel_size: int = 1,
         expert_model_parallel_size: int = 1,
@@ -199,6 +206,7 @@ class DeployRay:
         Args:
             nemo_checkpoint (str): Path to the .nemo checkpoint file.
             num_gpus (int, optional): Number of GPUs per node. Defaults to 1.
+            num_nodes (int, optional): Number of nodes for deployment. Defaults to 1.
             tensor_model_parallel_size (int, optional): Tensor model parallel size. Defaults to 1.
             pipeline_model_parallel_size (int, optional): Pipeline model parallel size. Defaults to 1.
             expert_model_parallel_size (int, optional): Expert model parallel size. Defaults to 1.
@@ -315,6 +323,7 @@ class DeployRay:
             num_gpus_per_replica (int, optional): GPUs per model replica. Defaults to 1.
             max_ongoing_requests (int, optional): Maximum number of ongoing requests per replica. Defaults to 10.
             test_mode (bool, optional): Enable test mode. Defaults to False.
+
         Raises:
             Exception: If Ray is not installed or deployment fails.
         """

--- a/nemo_deploy/nlp/hf_deployable_ray.py
+++ b/nemo_deploy/nlp/hf_deployable_ray.py
@@ -94,6 +94,7 @@ class HFRayDeployable:
                     max_memory_dict = {i: "75GiB" for i in range(num_gpus)}
             if use_vllm_backend:
                 from nemo_export.vllm_exporter import vLLMExporter
+
                 vllm_exporter = vLLMExporter()
                 vllm_exporter.export(model_path_id=hf_model_id_path)
                 self.model = vllm_exporter

--- a/nemo_deploy/nlp/hf_deployable_ray.py
+++ b/nemo_deploy/nlp/hf_deployable_ray.py
@@ -62,8 +62,8 @@ class HFRayDeployable:
         task: str = "text-generation",
         trust_remote_code: bool = True,
         model_id: str = "nemo-model",
-        device_map: str = "auto",
-        max_memory: str = None,
+        device_map: Optional[str] = None,
+        max_memory: Optional[str] = None,
         use_vllm_backend: bool = False,
     ):
         """Initialize the HuggingFace model deployment.
@@ -282,6 +282,7 @@ class HFRayDeployable:
                 "output_logits": request.get("output_logits", False),
                 "output_scores": request.get("output_scores", False),
             }
+
             # Run model inference in the thread pool
             results = self.model.ray_infer_fn(inference_inputs)
             # Extract generated texts from results
@@ -300,6 +301,7 @@ class HFRayDeployable:
             logits = results.get("logits", None)
             if logits is not None and isinstance(logits, np.ndarray):
                 logits = logits.tolist()
+
             output = {
                 "id": f"chatcmpl-{int(time.time())}",
                 "object": "chat.completion",

--- a/nemo_deploy/nlp/hf_deployable_ray.py
+++ b/nemo_deploy/nlp/hf_deployable_ray.py
@@ -62,8 +62,9 @@ class HFRayDeployable:
         task: str = "text-generation",
         trust_remote_code: bool = True,
         model_id: str = "nemo-model",
-        device_map: Optional[str] = None,
-        max_memory: Optional[str] = None,
+        device_map: str = "auto",
+        max_memory: str = None,
+        use_vllm_backend: bool = False,
     ):
         """Initialize the HuggingFace model deployment.
 
@@ -74,6 +75,8 @@ class HFRayDeployable:
             device_map (str): Device mapping strategy. Defaults to "auto".
             model_id (str): Model identifier. Defaults to "nemo-model".
             max_memory (str): Maximum memory allocation when using balanced device map.
+            use_vllm_backend (bool, optional): Whether to use vLLM backend for deployment. If True, exports the HF ckpt
+            to vLLM format and uses vLLM backend for inference. Defaults to False.
 
         Raises:
             ImportError: If Ray is not installed.
@@ -89,13 +92,19 @@ class HFRayDeployable:
                 if num_gpus > 1:
                     print(f"Using tensor parallel across {num_gpus} GPUs for large model")
                     max_memory_dict = {i: "75GiB" for i in range(num_gpus)}
-            self.model = HuggingFaceLLMDeploy(
-                hf_model_id_path=hf_model_id_path,
-                task=task,
-                trust_remote_code=trust_remote_code,
-                device_map=device_map,
-                max_memory=max_memory_dict,
-            )
+            if use_vllm_backend:
+                from nemo_export.vllm_exporter import vLLMExporter
+                vllm_exporter = vLLMExporter()
+                vllm_exporter.export(model_path_id=hf_model_id_path)
+                self.model = vllm_exporter
+            else:
+                self.model = HuggingFaceLLMDeploy(
+                    hf_model_id_path=hf_model_id_path,
+                    task=task,
+                    trust_remote_code=trust_remote_code,
+                    device_map=device_map,
+                    max_memory=max_memory_dict,
+                )
             self.model_id = model_id
 
         except Exception as e:
@@ -273,7 +282,6 @@ class HFRayDeployable:
                 "output_logits": request.get("output_logits", False),
                 "output_scores": request.get("output_scores", False),
             }
-
             # Run model inference in the thread pool
             results = self.model.ray_infer_fn(inference_inputs)
             # Extract generated texts from results
@@ -292,7 +300,6 @@ class HFRayDeployable:
             logits = results.get("logits", None)
             if logits is not None and isinstance(logits, np.ndarray):
                 logits = logits.tolist()
-
             output = {
                 "id": f"chatcmpl-{int(time.time())}",
                 "object": "chat.completion",
@@ -319,6 +326,8 @@ class HFRayDeployable:
                         ),
                         "finish_reason": (
                             "length"
+                            # inference_inputs["max_length"] errors out since max_length is popped from
+                            # inference_inputs in ray_infer_fn hence use request.get("max_tokens", 256)
                             if generated_texts and len(generated_texts[0]) >= request.get("max_tokens", 256)
                             else "stop"
                         ),

--- a/nemo_export/vllm_exporter.py
+++ b/nemo_export/vllm_exporter.py
@@ -455,6 +455,7 @@ class vLLMExporter(ITritonDeployable):
 
                 top_prompt_logprobs.append(lpbs)
 
+        # TODO athitten: If output contains input prompt + generated text, extract only the generated text.
         output = {"sentences": output}
         if len(top_logprobs) > 0:
             max_len = max(len(arr) for arr in top_logprobs)

--- a/nemo_export/vllm_exporter.py
+++ b/nemo_export/vllm_exporter.py
@@ -16,7 +16,7 @@
 import logging
 import tempfile
 from pathlib import Path
-from typing import List, Literal, Dict, Any
+from typing import Any, Dict, List, Literal
 
 import numpy as np
 

--- a/nemo_export/vllm_exporter.py
+++ b/nemo_export/vllm_exporter.py
@@ -455,7 +455,7 @@ class vLLMExporter(ITritonDeployable):
 
                 top_prompt_logprobs.append(lpbs)
 
-        # TODO athitten: If output contains input prompt + generated text, extract only the generated text.
+        # TODO athitten: extract only the generated text if output contains input prompt + generated text.
         output = {"sentences": output}
         if len(top_logprobs) > 0:
             max_len = max(len(arr) for arr in top_logprobs)

--- a/scripts/deploy/nlp/deploy_ray_hf.py
+++ b/scripts/deploy/nlp/deploy_ray_hf.py
@@ -117,6 +117,11 @@ def parse_args():
         default="0",
         help="Comma-separated list of CUDA visible devices",
     )
+    parser.add_argument(
+        "--use_vllm_backend",
+        action="store_true",
+        help="Whether to use vLLM backend for deployment",
+    )
     return parser.parse_args()
 
 
@@ -151,6 +156,7 @@ def main():
         num_cpus_per_replica=args.num_cpus_per_replica,
         num_gpus_per_replica=args.num_gpus_per_replica,
         max_ongoing_requests=args.max_ongoing_requests,
+        use_vllm_backend=args.use_vllm_backend,
     )
 
 

--- a/scripts/deploy/nlp/deploy_ray_inframework.py
+++ b/scripts/deploy/nlp/deploy_ray_inframework.py
@@ -163,7 +163,6 @@ def main():
     ray_deployer.deploy_inframework_model(
         nemo_checkpoint=args.nemo_checkpoint,
         num_gpus=args.num_gpus,
-        num_nodes=args.num_nodes,
         tensor_model_parallel_size=args.tensor_model_parallel_size,
         pipeline_model_parallel_size=args.pipeline_model_parallel_size,
         expert_model_parallel_size=args.expert_model_parallel_size,

--- a/scripts/deploy/nlp/deploy_ray_inframework.py
+++ b/scripts/deploy/nlp/deploy_ray_inframework.py
@@ -163,6 +163,7 @@ def main():
     ray_deployer.deploy_inframework_model(
         nemo_checkpoint=args.nemo_checkpoint,
         num_gpus=args.num_gpus,
+        num_nodes=args.num_nodes,
         tensor_model_parallel_size=args.tensor_model_parallel_size,
         pipeline_model_parallel_size=args.pipeline_model_parallel_size,
         expert_model_parallel_size=args.expert_model_parallel_size,

--- a/tests/unit_tests/deploy/test_deploy_ray_vllm_backend.py
+++ b/tests/unit_tests/deploy/test_deploy_ray_vllm_backend.py
@@ -93,7 +93,9 @@ class TestDeployRayVLLMBackend(unittest.TestCase):
     @patch("nemo_deploy.deploy_ray.HFRayDeployable")
     @patch("nemo_deploy.deploy_ray.signal.signal")
     @patch.object(DeployRay, "_start")
-    def test_deploy_hf_with_vllm_backend_default(self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray):
+    def test_deploy_hf_with_vllm_backend_default(
+        self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray
+    ):
         """Test deploy_huggingface_model with default use_vllm_backend (should be False)."""
         deploy = DeployRay()
 
@@ -121,7 +123,9 @@ class TestDeployRayVLLMBackend(unittest.TestCase):
     @patch("nemo_deploy.deploy_ray.HFRayDeployable")
     @patch("nemo_deploy.deploy_ray.signal.signal")
     @patch.object(DeployRay, "_start")
-    def test_deploy_hf_with_vllm_backend_and_other_params(self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray):
+    def test_deploy_hf_with_vllm_backend_and_other_params(
+        self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray
+    ):
         """Test deploy_huggingface_model with use_vllm_backend and other parameters."""
         deploy = DeployRay()
 
@@ -171,7 +175,9 @@ class TestDeployRayVLLMBackend(unittest.TestCase):
     @patch("nemo_deploy.deploy_ray.HFRayDeployable")
     @patch("nemo_deploy.deploy_ray.signal.signal")
     @patch.object(DeployRay, "_start")
-    def test_deploy_hf_vllm_backend_with_error_handling(self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray):
+    def test_deploy_hf_vllm_backend_with_error_handling(
+        self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray
+    ):
         """Test deploy_huggingface_model with use_vllm_backend=True and error handling."""
         deploy = DeployRay()
 
@@ -193,4 +199,3 @@ class TestDeployRayVLLMBackend(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/unit_tests/deploy/test_deploy_ray_vllm_backend.py
+++ b/tests/unit_tests/deploy/test_deploy_ray_vllm_backend.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from nemo_deploy.deploy_ray import DeployRay
+
+
+class TestDeployRayVLLMBackend(unittest.TestCase):
+    """Test cases for the use_vllm_backend parameter in deploy_huggingface_model method."""
+
+    def setUp(self):
+        # Ensure tests run even when Ray is not installed
+        self._have_ray_patcher = patch("nemo_deploy.deploy_ray.HAVE_RAY", True)
+        self._have_ray_patcher.start()
+
+    def tearDown(self):
+        self._have_ray_patcher.stop()
+
+    @patch("nemo_deploy.deploy_ray.ray")
+    @patch("nemo_deploy.deploy_ray.serve")
+    @patch("nemo_deploy.deploy_ray.HFRayDeployable")
+    @patch("nemo_deploy.deploy_ray.signal.signal")
+    @patch.object(DeployRay, "_start")
+    def test_deploy_hf_with_vllm_backend_true(self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray):
+        """Test deploy_huggingface_model with use_vllm_backend=True."""
+        deploy = DeployRay()
+
+        mock_app = MagicMock()
+        mock_options = MagicMock()
+        mock_options.bind.return_value = mock_app
+        mock_hf_deployable.options.return_value = mock_options
+
+        deploy.deploy_huggingface_model(
+            hf_model_id_path="test-hf-model",
+            model_id="test_model",
+            use_vllm_backend=True,
+            test_mode=True,
+        )
+
+        mock_start.assert_called_once()
+        mock_serve.run.assert_called_once_with(mock_app, name="test_model")
+        mock_hf_deployable.options.assert_called_once()
+
+        # Verify the bind call includes use_vllm_backend=True
+        _, bind_kwargs = mock_options.bind.call_args
+        assert bind_kwargs["use_vllm_backend"] is True
+
+    @patch("nemo_deploy.deploy_ray.ray")
+    @patch("nemo_deploy.deploy_ray.serve")
+    @patch("nemo_deploy.deploy_ray.HFRayDeployable")
+    @patch("nemo_deploy.deploy_ray.signal.signal")
+    @patch.object(DeployRay, "_start")
+    def test_deploy_hf_with_vllm_backend_false(self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray):
+        """Test deploy_huggingface_model with use_vllm_backend=False."""
+        deploy = DeployRay()
+
+        mock_app = MagicMock()
+        mock_options = MagicMock()
+        mock_options.bind.return_value = mock_app
+        mock_hf_deployable.options.return_value = mock_options
+
+        deploy.deploy_huggingface_model(
+            hf_model_id_path="test-hf-model",
+            model_id="test_model",
+            use_vllm_backend=False,
+            test_mode=True,
+        )
+
+        mock_start.assert_called_once()
+        mock_serve.run.assert_called_once_with(mock_app, name="test_model")
+        mock_hf_deployable.options.assert_called_once()
+
+        # Verify the bind call includes use_vllm_backend=False
+        _, bind_kwargs = mock_options.bind.call_args
+        assert bind_kwargs["use_vllm_backend"] is False
+
+    @patch("nemo_deploy.deploy_ray.ray")
+    @patch("nemo_deploy.deploy_ray.serve")
+    @patch("nemo_deploy.deploy_ray.HFRayDeployable")
+    @patch("nemo_deploy.deploy_ray.signal.signal")
+    @patch.object(DeployRay, "_start")
+    def test_deploy_hf_with_vllm_backend_default(self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray):
+        """Test deploy_huggingface_model with default use_vllm_backend (should be False)."""
+        deploy = DeployRay()
+
+        mock_app = MagicMock()
+        mock_options = MagicMock()
+        mock_options.bind.return_value = mock_app
+        mock_hf_deployable.options.return_value = mock_options
+
+        deploy.deploy_huggingface_model(
+            hf_model_id_path="test-hf-model",
+            model_id="test_model",
+            test_mode=True,
+        )
+
+        mock_start.assert_called_once()
+        mock_serve.run.assert_called_once_with(mock_app, name="test_model")
+        mock_hf_deployable.options.assert_called_once()
+
+        # Verify the bind call includes use_vllm_backend=False (default)
+        _, bind_kwargs = mock_options.bind.call_args
+        assert bind_kwargs["use_vllm_backend"] is False
+
+    @patch("nemo_deploy.deploy_ray.ray")
+    @patch("nemo_deploy.deploy_ray.serve")
+    @patch("nemo_deploy.deploy_ray.HFRayDeployable")
+    @patch("nemo_deploy.deploy_ray.signal.signal")
+    @patch.object(DeployRay, "_start")
+    def test_deploy_hf_with_vllm_backend_and_other_params(self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray):
+        """Test deploy_huggingface_model with use_vllm_backend and other parameters."""
+        deploy = DeployRay()
+
+        mock_app = MagicMock()
+        mock_options = MagicMock()
+        mock_options.bind.return_value = mock_app
+        mock_hf_deployable.options.return_value = mock_options
+
+        deploy.deploy_huggingface_model(
+            hf_model_id_path="test-hf-model",
+            task="text-generation",
+            trust_remote_code=True,
+            device_map="auto",
+            max_memory="16GB",
+            model_id="test_model",
+            num_replicas=2,
+            num_cpus_per_replica=4,
+            num_gpus_per_replica=1,
+            max_ongoing_requests=5,
+            use_vllm_backend=True,
+            test_mode=True,
+        )
+
+        mock_start.assert_called_once()
+        mock_serve.run.assert_called_once_with(mock_app, name="test_model")
+        mock_hf_deployable.options.assert_called_once()
+
+        # Verify all parameters are passed correctly
+        _, bind_kwargs = mock_options.bind.call_args
+        assert bind_kwargs["hf_model_id_path"] == "test-hf-model"
+        assert bind_kwargs["task"] == "text-generation"
+        assert bind_kwargs["trust_remote_code"] is True
+        assert bind_kwargs["device_map"] == "auto"
+        assert bind_kwargs["max_memory"] == "16GB"
+        assert bind_kwargs["model_id"] == "test_model"
+        assert bind_kwargs["use_vllm_backend"] is True
+
+        # Verify actor options
+        _, options_kwargs = mock_hf_deployable.options.call_args
+        assert options_kwargs["ray_actor_options"]["num_cpus"] == 4
+        assert options_kwargs["ray_actor_options"]["num_gpus"] == 1
+        assert options_kwargs["num_replicas"] == 2
+        assert options_kwargs["max_ongoing_requests"] == 5
+
+    @patch("nemo_deploy.deploy_ray.ray")
+    @patch("nemo_deploy.deploy_ray.serve")
+    @patch("nemo_deploy.deploy_ray.HFRayDeployable")
+    @patch("nemo_deploy.deploy_ray.signal.signal")
+    @patch.object(DeployRay, "_start")
+    def test_deploy_hf_vllm_backend_with_error_handling(self, mock_start, mock_signal, mock_hf_deployable, mock_serve, mock_ray):
+        """Test deploy_huggingface_model with use_vllm_backend=True and error handling."""
+        deploy = DeployRay()
+
+        # Simulate an error during deployment
+        mock_serve.run.side_effect = Exception("Deployment failed")
+
+        with self.assertRaises(SystemExit):
+            deploy.deploy_huggingface_model(
+                hf_model_id_path="test-hf-model",
+                model_id="test_model",
+                use_vllm_backend=True,
+                test_mode=True,
+            )
+
+        # Verify _stop is called on error
+        mock_serve.shutdown.assert_called_once()
+        mock_ray.shutdown.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/unit_tests/deploy/test_hf_deployable.py
+++ b/tests/unit_tests/deploy/test_hf_deployable.py
@@ -38,6 +38,7 @@ def mock_tokenizer():
     tokenizer.pad_token = "[PAD]"
     tokenizer.eos_token = "[EOS]"
     tokenizer.batch_decode = MagicMock(return_value=["Generated text"])
+    tokenizer.decode = MagicMock(return_value="Generated text")
     tokenizer.return_value = {
         "input_ids": torch.tensor([[1, 2, 3]]),
         "attention_mask": torch.tensor([[1, 1, 1]]),
@@ -163,7 +164,8 @@ class TestHuggingFaceLLMDeploy:
         output = deployer.generate(text_inputs=["test prompt"])
         assert output == ["Generated text"]
         mock_model.generate.assert_called_once()
-        mock_tokenizer.batch_decode.assert_called_once()
+        # self.tokenizer.decode is used instead of tokenizer.batch_decode to convert the generated tokens to text.
+        mock_tokenizer.decode.assert_called_once()
 
     def test_generate_with_output_logits_and_scores(self, mock_model, mock_tokenizer, mock_torch_cuda):
         mock_model.generate.return_value = {

--- a/tests/unit_tests/export/test_vllm_exporter_ray_infer.py
+++ b/tests/unit_tests/export/test_vllm_exporter_ray_infer.py
@@ -1,0 +1,357 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+try:
+    import vllm  # noqa: F401
+
+    HAVE_VLLM = True
+except ImportError:
+    HAVE_VLLM = False
+
+
+@pytest.fixture
+def exporter():
+    from nemo_export.vllm_exporter import vLLMExporter
+
+    return vLLMExporter()
+
+
+@pytest.fixture
+def mock_llm():
+    with patch("nemo_export.vllm_exporter.LLM") as mock:
+        mock_instance = MagicMock()
+        mock.return_value = mock_instance
+        yield mock
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_basic_usage(exporter, mock_llm):
+    """Test ray_infer_fn with basic input."""
+    # Mock the forward method
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(return_value={"sentences": ["Generated text"]})
+
+    inputs = {
+        "prompts": ["Hello, how are you?"],
+        "max_tokens": 50,
+        "temperature": 0.7,
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == ["Generated text"]
+    exporter.forward.assert_called_once_with(
+        input_texts=["Hello, how are you?"],
+        max_tokens=50,
+        temperature=0.7,
+    )
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_single_string_prompt(exporter, mock_llm):
+    """Test ray_infer_fn with single string prompt (should be converted to list)."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(return_value={"sentences": ["Generated text"]})
+
+    inputs = {
+        "prompts": "Hello, how are you?",
+        "max_tokens": 50,
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == ["Generated text"]
+    exporter.forward.assert_called_once_with(
+        input_texts=["Hello, how are you?"],
+        max_tokens=50,
+    )
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_with_all_parameters(exporter, mock_llm):
+    """Test ray_infer_fn with all possible parameters."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(return_value={"sentences": ["Generated text"]})
+
+    inputs = {
+        "prompts": ["Hello, how are you?"],
+        "max_tokens": 100,
+        "min_tokens": 10,
+        "top_k": 50,
+        "top_p": 0.9,
+        "temperature": 0.8,
+        "seed": 42,
+        "n_log_probs": 5,
+        "n_prompt_log_probs": 3,
+        "lora_model_name": "test_lora",
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == ["Generated text"]
+    exporter.forward.assert_called_once_with(
+        input_texts=["Hello, how are you?"],
+        max_tokens=100,
+        min_tokens=10,
+        top_k=50,
+        top_p=0.9,
+        temperature=0.8,
+        seed=42,
+        n_log_probs=5,
+        n_prompt_log_probs=3,
+        lora_model_name="test_lora",
+    )
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_with_log_probs(exporter, mock_llm):
+    """Test ray_infer_fn with log probabilities in output."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(
+        return_value={
+            "sentences": ["Generated text"],
+            "log_probs": [["token1", "token2"]],
+            "prompt_log_probs": [["prompt_token1"]],
+        }
+    )
+
+    inputs = {
+        "prompts": ["Hello, how are you?"],
+        "n_log_probs": 2,
+        "n_prompt_log_probs": 1,
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == ["Generated text"]
+    assert result["log_probs"] == [["token1", "token2"]]
+    assert result["prompt_log_probs"] == [["prompt_token1"]]
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_with_empty_prompts(exporter, mock_llm):
+    """Test ray_infer_fn with empty prompts list."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(return_value={"sentences": []})
+
+    inputs = {
+        "prompts": [],
+        "max_tokens": 50,
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == []
+    exporter.forward.assert_called_once_with(
+        input_texts=[],
+        max_tokens=50,
+    )
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_with_multiple_prompts(exporter, mock_llm):
+    """Test ray_infer_fn with multiple prompts."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(return_value={"sentences": ["Text 1", "Text 2", "Text 3"]})
+
+    inputs = {
+        "prompts": ["Prompt 1", "Prompt 2", "Prompt 3"],
+        "max_tokens": 50,
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == ["Text 1", "Text 2", "Text 3"]
+    exporter.forward.assert_called_once_with(
+        input_texts=["Prompt 1", "Prompt 2", "Prompt 3"],
+        max_tokens=50,
+    )
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_with_forward_error(exporter, mock_llm):
+    """Test ray_infer_fn when forward method raises an exception."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(side_effect=Exception("Forward error"))
+
+    inputs = {
+        "prompts": ["Hello, how are you?"],
+        "max_tokens": 50,
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert "error" in result
+    assert result["error"] == "An error occurred: Forward error"
+    assert result["sentences"] == ["An error occurred: Forward error"]
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_with_forward_error_multiple_prompts(exporter, mock_llm):
+    """Test ray_infer_fn when forward method raises an exception with multiple prompts."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(side_effect=Exception("Forward error"))
+
+    inputs = {
+        "prompts": ["Prompt 1", "Prompt 2", "Prompt 3"],
+        "max_tokens": 50,
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert "error" in result
+    assert result["error"] == "An error occurred: Forward error"
+    assert result["sentences"] == [
+        "An error occurred: Forward error",
+        "An error occurred: Forward error",
+        "An error occurred: Forward error",
+    ]
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_with_forward_dict_output(exporter, mock_llm):
+    """Test ray_infer_fn when forward returns a dict output."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(return_value={"sentences": ["Generated text"], "custom_field": "value"})
+
+    inputs = {
+        "prompts": ["Hello, how are you?"],
+        "max_tokens": 50,
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == ["Generated text"]
+    assert result["custom_field"] == "value"
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_with_forward_non_dict_output(exporter, mock_llm):
+    """Test ray_infer_fn when forward returns a non-dict output."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(return_value="Not a dict")
+
+    inputs = {
+        "prompts": ["Hello, how are you?"],
+        "max_tokens": 50,
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == ["An error occurred: the output format is expected to be a dict."]
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_with_missing_prompts(exporter, mock_llm):
+    """Test ray_infer_fn with missing prompts key."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(return_value={"sentences": []})
+
+    inputs = {
+        "max_tokens": 50,
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == []
+    exporter.forward.assert_called_once_with(
+        input_texts=[],
+        max_tokens=50,
+    )
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_parameter_type_conversion(exporter, mock_llm):
+    """Test ray_infer_fn ensures proper type conversion of parameters."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(return_value={"sentences": ["Generated text"]})
+
+    inputs = {
+        "prompts": ["Hello, how are you?"],
+        "max_tokens": "50",  # String instead of int
+        "temperature": "0.7",  # String instead of float
+        "top_k": "10",  # String instead of int
+        "top_p": "0.9",  # String instead of float
+        "seed": "42",  # String instead of int
+        "n_log_probs": "5",  # String instead of int
+        "n_prompt_log_probs": "3",  # String instead of int
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == ["Generated text"]
+    # Verify that the _infer_fn method handles type conversion
+    exporter.forward.assert_called_once_with(
+        input_texts=["Hello, how are you?"],
+        max_tokens=50,
+        temperature=0.7,
+        top_k=10,
+        top_p=0.9,
+        seed=42,
+        n_log_probs=5,
+        n_prompt_log_probs=3,
+    )
+
+
+@pytest.mark.skipif(not HAVE_VLLM, reason="Need to enable virtual environment for vLLM")
+@pytest.mark.run_only_on("GPU")
+def test_ray_infer_fn_with_numpy_arrays(exporter, mock_llm):
+    """Test ray_infer_fn with numpy array inputs."""
+    exporter.model = MagicMock()
+    exporter.forward = MagicMock(return_value={"sentences": ["Generated text"]})
+
+    inputs = {
+        "prompts": ["Hello, how are you?"],
+        "max_tokens": np.array([50]),
+        "temperature": np.array([0.7]),
+        "top_k": np.array([10]),
+        "top_p": np.array([0.9]),
+        "seed": np.array([42]),
+        "n_log_probs": np.array([5]),
+        "n_prompt_log_probs": np.array([3]),
+    }
+
+    result = exporter.ray_infer_fn(inputs)
+
+    assert result["sentences"] == ["Generated text"]
+    # Verify that numpy arrays are properly converted
+    exporter.forward.assert_called_once_with(
+        input_texts=["Hello, how are you?"],
+        max_tokens=50,
+        temperature=0.7,
+        top_k=10,
+        top_p=0.9,
+        seed=42,
+        n_log_probs=5,
+        n_prompt_log_probs=3,
+    )
+

--- a/tests/unit_tests/export/test_vllm_exporter_ray_infer.py
+++ b/tests/unit_tests/export/test_vllm_exporter_ray_infer.py
@@ -354,4 +354,3 @@ def test_ray_infer_fn_with_numpy_arrays(exporter, mock_llm):
         n_log_probs=5,
         n_prompt_log_probs=3,
     )
-


### PR DESCRIPTION
1) Exposes arg `use_vllm_backend` to deploy HF model via vllm backend (using the `vLLMExporter` class) for accelerated inference or evaluation of HF models. 
2) Adds `ray_infer_fn` method to `vLLMExporter` class by extracting the common logic between `triton_infer_fn` and `ray_infer_fn` to `_infer_fn` along the same lines as [MegatronLLMDeployable](https://github.com/NVIDIA-NeMo/Export-Deploy/blob/main/nemo_deploy/nlp/megatronllm_deployable.py#L119) and [TRTLLM](https://github.com/NVIDIA-NeMo/Export-Deploy/blob/main/nemo_export/tensorrt_llm.py#L966)