### PR TITLE
Adding sbatch script for multi-node deployment support

### DIFF
--- a/nemo_deploy/nlp/megatronllm_deployable_ray.py
+++ b/nemo_deploy/nlp/megatronllm_deployable_ray.py
@@ -19,6 +19,7 @@ import time
 from typing import Any, Dict, Optional
 
 import numpy as np
+import random
 import ray
 import torch
 from fastapi import FastAPI, HTTPException
@@ -173,7 +174,7 @@ class MegatronRayDeployable:
 
             # Pre-allocate master port to avoid race conditions between workers
             # Use replica-specific port to avoid conflicts between replicas
-            base_port = 29500 + (replica_id % 100) * 100
+            base_port = random.randint(29500, 29999) + (replica_id % 100) * 100
             master_port = str(find_available_port(base_port, ray._private.services.get_node_ip_address()))
             LOGGER.info(f"Replica {replica_id} - Pre-allocated master port: {master_port}")
 

--- a/scripts/deploy/nlp/deploy_ray_inframework.py
+++ b/scripts/deploy/nlp/deploy_ray_inframework.py
@@ -103,7 +103,7 @@ def parse_args():
     parser.add_argument(
         "--cuda_visible_devices",
         type=str,
-        default="0,1",
+        default=None,
         help="Comma-separated list of CUDA visible devices",
     )
     parser.add_argument(
@@ -170,17 +170,19 @@ def main():
     """Main function to deploy a Megatron model using Ray."""
     args = parse_args()
     # Initialize Ray deployment with updated DeployRay class
+    runtime_env = {}
+    if args.cuda_visible_devices is not None:
+        runtime_env["env_vars"] = {
+            "CUDA_VISIBLE_DEVICES": args.cuda_visible_devices,
+        }
+
     ray_deployer = DeployRay(
         num_cpus=args.num_cpus,
         num_gpus=args.num_gpus,
         include_dashboard=args.include_dashboard,
         host=args.host,
         port=args.port,
-        runtime_env={
-            "env_vars": {
-                "CUDA_VISIBLE_DEVICES": args.cuda_visible_devices,
-            }
-        },
+        runtime_env=runtime_env
     )
 
     # Deploy the inframework model using the updated API


### PR DESCRIPTION
Adding ray.sub for creating a multi-node cluster to support Ray Serve deployments.