### PR TITLE
chore(beep boop 🤖): Bump `uv.lock` (r0.2.0) (2025-08-26)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3629,7 +3629,7 @@ wheels = [
 
 [[package]]
 name = "megatron-bridge"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accelerate" },
@@ -3659,9 +3659,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "wandb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/85/1a7cfdf73dbe6b547040a05057a4a96b3bcd70ae6e32b69cdce297f857f1/megatron_bridge-0.1.0rc1.tar.gz", hash = "sha256:4ad9d5d948b64cca5c085ab933563c0d0e99de6c114017133074e366d47edaea", size = 310608, upload-time = "2025-08-18T06:29:49.526Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/69/7307e6aa41e680ac3f85d9f21b53989177e62af4ec302f3f9eb9481ecda1/megatron_bridge-0.1.0rc2.tar.gz", hash = "sha256:17e10461c56682ec2d74f590110b538de7e4b345bdd42ce33d0f8c31c62f17f2", size = 320360, upload-time = "2025-08-26T16:45:51.479Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/a4/8cbd735a3a85699a218315b59aa702810652804ddee41010673e022c86cc/megatron_bridge-0.1.0rc1-py3-none-any.whl", hash = "sha256:70bb53131d308e44da36bf7d1b798dfee552300449b0dd3386e0f5d14f72cd01", size = 450230, upload-time = "2025-08-18T06:29:47.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/20/2f452d7d96fd874322cb40d1a045253690bcf42ac17d76c43ba7bb9fa5e7/megatron_bridge-0.1.0rc2-py3-none-any.whl", hash = "sha256:65cd63d288ecaecd9a68f01a49b29d26ddca3f89b47f419c0e9d6e5a4d49d15c", size = 518378, upload-time = "2025-08-26T16:45:50.243Z" },
 ]
 
 [[package]]
@@ -5638,11 +5638,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.8"
+version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
🚀 PR to bump `uv.lock` in `r0.2.0`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.