### PR TITLE
fix: ensure vLLM receives valid params regardless of env changes

### DIFF
--- a/nemo_deploy/llm/hf_deployable_ray.py
+++ b/nemo_deploy/llm/hf_deployable_ray.py
@@ -173,10 +173,12 @@ class HFRayDeployable:
                 request["prompts"] = [request["prompt"]]
             temperature = request.get("temperature", 0.0)
             top_p = request.get("top_p", None)
-            
+
             # vLLM requires top_p to be in (0, 1], so handle invalid values
             if top_p is not None and top_p <= 0.0:
-                LOGGER.warning(f"top_p must be in (0, 1] for vLLM, got {top_p}. Setting to 0.1 for greedy-like sampling.")
+                LOGGER.warning(
+                    f"top_p must be in (0, 1] for vLLM, got {top_p}. Setting to 0.1 for greedy-like sampling."
+                )
                 request["top_p"] = 0.1
                 if temperature == 0.0:
                     LOGGER.warning("Both temperature and top_p are 0. Setting top_k to 1 to ensure greedy sampling.")
@@ -291,11 +293,13 @@ class HFRayDeployable:
         try:
             # Extract parameters from the request dictionary
             messages = request.get("messages", [])
-            
+
             # vLLM requires top_p to be in (0, 1], so handle invalid values
             top_p = request.get("top_p", None)
             if top_p is not None and top_p <= 0.0:
-                LOGGER.warning(f"top_p must be in (0, 1] for vLLM, got {top_p}. Setting to 0.1 for greedy-like sampling.")
+                LOGGER.warning(
+                    f"top_p must be in (0, 1] for vLLM, got {top_p}. Setting to 0.1 for greedy-like sampling."
+                )
                 request["top_p"] = 0.1
 
             # Convert messages to a single prompt


### PR DESCRIPTION
In vLLM , top_p is a parameter used in nucleus sampling, which controls how tokens are selected during generation.
What top_p Does

Instead of picking from the entire vocabulary, vLLM considers only the smallest set of tokens whose cumulative probability exceeds p.
For example:

top_p = 0.9 → Only tokens that together make up 90% of the probability mass are considered.
This helps avoid very low-probability tokens while still allowing diversity.



Key Points

Range: 0 < top_p ≤ 1
Lower values (e.g., 0.8) → More restrictive, less diverse output.
Higher values (e.g., 0.95 or 1.0) → More diverse, closer to full sampling.
Often used together with temperature for fine control over randomness.