### PR TITLE
Properly Handle DynamicInferenceRequestRecord with latest Mcore

### DIFF
--- a/nemo_deploy/llm/megatronllm_deployable.py
+++ b/nemo_deploy/llm/megatronllm_deployable.py
@@ -471,7 +471,9 @@ class MegatronLLMDeployableNemo2(ITritonDeployable):
 
         results = self.generate(prompts, inference_params)
         # Handle DynamicInferenceRequestRecord objects by merging them into a single request
-        results = [r.merge(self.mcore_tokenizer) if isinstance(r, DynamicInferenceRequestRecord) else r for r in results]
+        results = [
+            r.merge(self.mcore_tokenizer) if isinstance(r, DynamicInferenceRequestRecord) else r for r in results
+        ]
         if echo:
             output_texts = [r.prompt + r.generated_text if text_only else r for r in results]
         else:


### PR DESCRIPTION
Latest versions of Megatron-Core's inference engine return `DynamicInferenceRequestRecord` objects instead of `InferenceRequest` objects. The `DynamicInferenceRequestRecord` is a container class that holds multiple `DynamicInferenceRequest` objects (to support suspend/resume functionality) and doesn't have a direct generated_text attribute.

Added handling after generate() to merge DynamicInferenceRequestRecord objects in this PR