### PR TITLE
Properly Handle DynamicInferenceRequestRecord with latest Mcore

### DIFF
--- a/nemo_deploy/llm/megatronllm_deployable.py
+++ b/nemo_deploy/llm/megatronllm_deployable.py
@@ -22,7 +22,7 @@ import torch
 import torch.distributed
 from jinja2 import Template
 from megatron.core.inference.common_inference_params import CommonInferenceParams
-from megatron.core.inference.inference_request import DynamicInferenceRequestRecord, InferenceRequest
+from megatron.core.inference.inference_request import InferenceRequest
 
 from nemo_deploy import ITritonDeployable
 from nemo_deploy.llm.inference.inference_base import create_mcore_engine
@@ -472,7 +472,7 @@ class MegatronLLMDeployableNemo2(ITritonDeployable):
         results = self.generate(prompts, inference_params)
         # Handle DynamicInferenceRequestRecord objects by merging them into a single request
         results = [
-            r.merge(self.mcore_tokenizer) if isinstance(r, DynamicInferenceRequestRecord) else r for r in results
+            r.merge(self.mcore_tokenizer) if type(r).__name__ == "DynamicInferenceRequestRecord" else r for r in results
         ]
         if echo:
             output_texts = [r.prompt + r.generated_text if text_only else r for r in results]


### PR DESCRIPTION
Trying to include the fix from https://github.com/NVIDIA-NeMo/Export-Deploy/pull/536 without upgrading MCore for now.  There's a lot more involved in updating MCore that will take a little more time.

From that PR by @suiyoubi :
```
Latest versions of Megatron-Core's inference engine return DynamicInferenceRequestRecord objects instead of InferenceRequest objects. The DynamicInferenceRequestRecord is a container class that holds multiple DynamicInferenceRequest objects (to support suspend/resume functionality) and doesn't have a direct generated_text attribute.

Added handling after generate() to merge DynamicInferenceRequestRecord objects in this PR
```

Previously, the Eval team's integration test was failing because it ran in the nightly NeMo FW container with latest MCore.  
https://github.com/NVIDIA-NeMo/Evaluator/actions/runs/21135187589/job/60775766423

With this fix, those integration tests will pass:
https://github.com/NVIDIA-NeMo/Evaluator/actions/runs/21140045395/job/60791762482?pr=639