### PR TITLE
Update CI docker image and set vllm eager enforce_eager to False

### DIFF
--- a/docker/Dockerfile.pytorch
+++ b/docker/Dockerfile.pytorch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidian/nemo:export-deploy-25.11-py3-48b7b5d-v0.14.1
+FROM nvcr.io/nvidian/nemo:export-deploy-25.11-py3-48b7b5d-v0.14.1-torch-version-patch
 WORKDIR /workspace
 COPY . .
 ARG INFERENCE_FRAMEWORK

--- a/tests/unit_tests/export/test_vllm_exporter.py
+++ b/tests/unit_tests/export/test_vllm_exporter.py
@@ -20,7 +20,6 @@ import pytest
 
 try:
     import vllm  # noqa: F401
-    from vllm.config.compilation import CompilationConfig, DynamicShapesConfig
 
     HAVE_VLLM = True
 except ImportError:
@@ -72,7 +71,6 @@ def test_export(exporter, mock_llm):
         cpu_offload_gb=0,
         enforce_eager=False,
         runner="auto",
-        compilation_config=CompilationConfig(dynamic_shapes_config=DynamicShapesConfig(assume_32_bit_indexing=False)),
     )
 
 
@@ -98,7 +96,6 @@ def test_export_with_lora(exporter, mock_llm):
         cpu_offload_gb=0,
         enforce_eager=False,
         runner="auto",
-        compilation_config=CompilationConfig(dynamic_shapes_config=DynamicShapesConfig(assume_32_bit_indexing=False)),
     )
 
 
@@ -130,7 +127,6 @@ def test_export_with_custom_params(exporter, mock_llm):
         cpu_offload_gb=0,
         enforce_eager=False,
         runner="auto",
-        compilation_config=CompilationConfig(dynamic_shapes_config=DynamicShapesConfig(assume_32_bit_indexing=False)),
     )
 
 
@@ -864,6 +860,3 @@ def test_export_megatron_bridge_with_all_vllm_params(exporter, mock_llm):
         assert call_kwargs["cpu_offload_gb"] == 2
         assert call_kwargs["enforce_eager"] is False
         assert call_kwargs["runner"] == "generate"
-        assert call_kwargs["compilation_config"] == CompilationConfig(
-            dynamic_shapes_config=DynamicShapesConfig(assume_32_bit_indexing=False)
-        )


### PR DESCRIPTION
Update CI docker image and set vllm eager enforce_eager to False

vllm checks if certain torch features are available based on the torch version. In particular, vllm 0.14.1 assumes 32 bit indexing is available for torch versions >= 2.10.0.dev. However, when installed in the 25.11 NGC Pytorch container, vllm believes that feature should work with the container's torch version. But this is not correct.

https://github.com/vllm-project/vllm/blob/v0.14.1/vllm/compilation/decorators.py#L524

So, this change updates the CI docker image with a patched version of vllm that does not treat the 25.11 NGC Pytorch version as >= 2.10.0.dev.  We also previously set the VLLMExporter to default to enforce_eager=True.  This change should enable enforce_eager=False.  