### PR TITLE
Fix release workflow reference

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ permissions:
 
 jobs:
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@0.76.1
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.77.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo_export_deploy_common


### PR DESCRIPTION
Fix release workflow reference

It was originally referencing `0.76.1`.  It was missing the "v".  Bumping to latest 0.77.0.