### PR TITLE
build: drop rc0 pre-release tag and add dynamic git versioning

### DIFF
--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -43,7 +43,7 @@ jobs:
     if: |
       !(needs.pre-flight.outputs.docs_only == 'true'
       || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.70.1
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@7a6fd6d27f422af24f853346bc738d31af0338c0
     with:
       dry-run: true
       python-package: nemo_export_deploy_common

--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -43,7 +43,7 @@ jobs:
     if: |
       !(needs.pre-flight.outputs.docs_only == 'true'
       || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@7a6fd6d27f422af24f853346bc738d31af0338c0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.88.1
     with:
       dry-run: true
       python-package: nemo_export_deploy_common

--- a/nemo_export_deploy_common/package_info.py
+++ b/nemo_export_deploy_common/package_info.py
@@ -24,7 +24,7 @@ VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)
 __shortversion__ = ".".join(map(str, VERSION[:3]))
 __version__ = ".".join(map(str, VERSION[:3])) + "".join(VERSION[3:])
 
-import os as _os
+import os as _os  # noqa: I001
 import subprocess as _subprocess
 
 

--- a/nemo_export_deploy_common/package_info.py
+++ b/nemo_export_deploy_common/package_info.py
@@ -27,6 +27,7 @@ __version__ = ".".join(map(str, VERSION[:3])) + "".join(VERSION[3:])
 import os as _os
 import subprocess as _subprocess
 
+
 if not int(_os.getenv("NO_VCS_VERSION", "0")):
     try:
         _git = _subprocess.run(

--- a/nemo_export_deploy_common/package_info.py
+++ b/nemo_export_deploy_common/package_info.py
@@ -16,13 +16,30 @@
 MAJOR = 0
 MINOR = 6
 PATCH = 0
-PRE_RELEASE = "rc0"
+PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)
 
 __shortversion__ = ".".join(map(str, VERSION[:3]))
 __version__ = ".".join(map(str, VERSION[:3])) + "".join(VERSION[3:])
+
+import os as _os
+import subprocess as _subprocess
+
+if not int(_os.getenv("NO_VCS_VERSION", "0")):
+    try:
+        _git = _subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            cwd=_os.path.dirname(_os.path.abspath(__file__)),
+            check=True,
+            universal_newlines=True,
+        )
+    except (_subprocess.CalledProcessError, OSError):
+        pass
+    else:
+        __version__ += f"+{_git.stdout.strip()}"
 
 __package_name__ = "nemo_export_deploy"
 __contact_names__ = "NVIDIA"


### PR DESCRIPTION
## Summary

- Drops the `rc0` pre-release tag — version is now `X.Y.Z` (clean semver)
- Appends `+<short-sha>` to `__version__` at import/build time via `git rev-parse --short HEAD`
- Gracefully falls back to the base version if git is unavailable or the code is not in a git repo
- Set `NO_VCS_VERSION=1` to opt out (e.g. for release builds)
- Pins `build-test-publish-wheel` to `FW-CI-templates@7a6fd6d` (sets `NO_VCS_VERSION=1` in the build step to prevent sdist/wheel version mismatch); will be replaced with a version tag once NVIDIA-NeMo/FW-CI-templates#443 is released

## Example

```python
>>> from nemo_export_deploy_common.package_info import __version__; print(__version__)
'0.6.0+b16a7044'

>>> NO_VCS_VERSION=1 python -c "from nemo_export_deploy_common.package_info import __version__; print(__version__)"
0.6.0
```

## Test plan

- [ ] CI build-test-publish-wheel workflow passes