### PR TITLE
docs: bump project.json and versions1.json to 0.5.0

### DIFF
--- a/docs/project.json
+++ b/docs/project.json
@@ -1,4 +1,4 @@
 {
     "name": "NeMo-Export-Deploy",
-    "version": "nightly"
+    "version": "0.5.0"
 }

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -4,10 +4,15 @@
         "url": "https://docs.nvidia.com/nemo/export-deploy/nightly/"
     },
     {
-        "name": "0.4.0 (latest)",
-        "version": "0.4.0",
+        "name": "0.5.0 (latest)",
+        "version": "0.5.0",
         "url": "https://docs.nvidia.com/nemo/export-deploy/latest/",
         "preferred": true
+    },
+    {
+        "name": "0.4.0",
+        "version": "0.4.0",
+        "url": "https://docs.nvidia.com/nemo/export-deploy/0.4.0/"
     },
     {
         "version": "0.3.0",


### PR DESCRIPTION
## Summary

- `project.json`: version `nightly` → `0.5.0`
- `versions1.json`: adds `0.5.0 (latest)`, demotes `0.4.0` to versioned URL

## Before / After

**`project.json` before:**
```json
{"name": "NeMo-Export-Deploy", "version": "nightly"}
```
**`project.json` after:**
```json
{"name": "NeMo-Export-Deploy", "version": "0.5.0"}
```

**`versions1.json` before:**
```json
{ "name": "0.4.0 (latest)", "version": "0.4.0", "url": ".../latest/", "preferred": true }
```
**`versions1.json` after:**
```json
{ "name": "0.5.0 (latest)", "version": "0.5.0", "url": ".../latest/", "preferred": true },
{ "name": "0.4.0", "version": "0.4.0", "url": ".../0.4.0/" }
```