### PR TITLE
[docs] ci: fix release version to 0.5.0 in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ import sys
 project = "NeMo-Export-Deploy"
 copyright = "2026, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = "nightly"
+release = "0.5.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
## Summary

Fixes `release = "nightly"` → `"0.5.0"` in `docs/conf.py` so the Sphinx version picker correctly highlights **0.5.0** as the current version instead of "nightly".

Same fix as NVIDIA/Megatron-LM@911bc4c128.