### PR TITLE
ci: Bump CI image to 26.04 pytorch and 0.20.1 vllm

### DIFF
--- a/docker/Dockerfile.pytorch
+++ b/docker/Dockerfile.pytorch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidian/nemo:export-deploy-26.02-py3-1.2.0-v0.17.1
+FROM nvcr.io/nvidian/nemo:export-deploy-pyt-26.04-vllm-v0.20.1
 WORKDIR /workspace
 COPY . .
 ARG INFERENCE_FRAMEWORK


### PR DESCRIPTION
ci: Bump CI image to 26.04 pytorch and 0.20.1 vllm

I thought I did this but evidently not. The current container RCs are running into errors for vllm export. I opened a PR in MBridge repo with a patch to vllm to fix.

https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/4002