### PR TITLE
fix: use eager attention for bidirectional ONNX export

### DIFF
--- a/nemo_export/model_adapters/embedding/embedding_adapter.py
+++ b/nemo_export/model_adapters/embedding/embedding_adapter.py
@@ -193,6 +193,7 @@ def get_llama_bidirectional_hf_model(
     pooling_mode: Optional[Literal["avg", "cls", "last"]] = None,
     torch_dtype: Optional[Union[torch.dtype, str]] = None,
     trust_remote_code: bool = False,
+    attn_implementation: Optional[str] = None,
 ):
     """
     Factory function to create a LlamaBidirectionalHFAdapter with proper configuration.
@@ -213,6 +214,8 @@ def get_llama_bidirectional_hf_model(
                      - "cls" becomes "cls__left" for left-padding tokenizers
         torch_dtype: The torch data type to use for the model. If None, uses model default.
         trust_remote_code: Whether to trust remote code when loading the model.
+        attn_implementation: Attention implementation to use. Use "eager" for
+                           ONNX export compatibility with bidirectional Llama models.
 
     Returns:
         tuple: A tuple containing:
@@ -236,9 +239,18 @@ def get_llama_bidirectional_hf_model(
         pooling_mode = "cls__left"  # type: ignore
 
     # load the model
-    model = AutoModel.from_pretrained(
-        model_name_or_path, torch_dtype=torch_dtype, trust_remote_code=trust_remote_code
-    ).eval()
+    model_kwargs = {
+        "torch_dtype": torch_dtype,
+        "trust_remote_code": trust_remote_code,
+    }
+    if attn_implementation is not None:
+        model_kwargs["attn_implementation"] = attn_implementation
+
+    model = AutoModel.from_pretrained(model_name_or_path, **model_kwargs).eval()
+
+    if attn_implementation:
+        # Reset config in case remote-code init mutates the selected attention implementation.
+        model.config._attn_implementation = attn_implementation
 
     # configure pooling
     pooling_module = Pooling(pooling_mode=pooling_mode)
@@ -251,6 +263,8 @@ def get_llama_bidirectional_hf_model(
     ):
         pooling_module = model.latent_attention_model
         model = model.embedding_model
+        if attn_implementation:
+            model.config._attn_implementation = attn_implementation
 
     adapted_model = LlamaBidirectionalHFAdapter(model=model, normalize=normalize, pooling_module=pooling_module)
     return adapted_model, tokenizer

--- a/tests/functional_tests/utils/run_onnx_trt_embedding_export.py
+++ b/tests/functional_tests/utils/run_onnx_trt_embedding_export.py
@@ -53,6 +53,13 @@ def get_args():
     )
     parser.add_argument("--onnx_opset", type=int, default=17, help="ONNX version to use for export.")
     parser.add_argument(
+        "--attn_implementation",
+        type=str,
+        default="eager",
+        choices=["eager", "sdpa", "flash_attention_2"],
+        help="Attention implementation to use while tracing. Use eager for ONNX export.",
+    )
+    parser.add_argument(
         "--trt_model_path",
         type=str,
         default="/tmp/trt_model_embedding/",
@@ -98,6 +105,7 @@ def export_onnx_trt(args):
         normalize=args.normalize,
         pooling_mode=args.pooling_strategy,
         trust_remote_code=True,
+        attn_implementation=args.attn_implementation,
     )
 
     input_names = [

--- a/tests/functional_tests/utils/run_onnx_trt_reranking_export.py
+++ b/tests/functional_tests/utils/run_onnx_trt_reranking_export.py
@@ -38,6 +38,13 @@ def get_args():
     )
     parser.add_argument("--onnx_opset", type=int, default=17, help="ONNX version to use for export.")
     parser.add_argument(
+        "--attn_implementation",
+        type=str,
+        default="eager",
+        choices=["eager", "sdpa", "flash_attention_2"],
+        help="Attention implementation to use while tracing. Use eager for ONNX export.",
+    )
+    parser.add_argument(
         "--trt_model_path",
         type=str,
         default="/tmp/trt_model_reranker/",
@@ -58,6 +65,7 @@ def export_onnx_trt(args):
     model, tokenizer = get_llama_reranker_hf_model(
         model_name_or_path=args.hf_model_path,
         trust_remote_code=True,
+        attn_implementation=args.attn_implementation,
     )
 
     input_names = [

--- a/tests/functional_tests/utils/test_export_onnx.py
+++ b/tests/functional_tests/utils/test_export_onnx.py
@@ -55,6 +55,13 @@ def get_args():
     )
     parser.add_argument("--onnx_opset", type=int, default=17, help="ONNX version to use for export.")
     parser.add_argument(
+        "--attn_implementation",
+        type=str,
+        default="eager",
+        choices=["eager", "sdpa", "flash_attention_2"],
+        help="Attention implementation to use while tracing. Use eager for ONNX export.",
+    )
+    parser.add_argument(
         "--trt_model_path",
         type=str,
         default="/tmp/trt_model/",
@@ -100,6 +107,7 @@ def export_onnx_trt(args):
         normalize=args.normalize,
         pooling_mode=args.pooling_strategy,
         trust_remote_code=True,
+        attn_implementation=args.attn_implementation,
     )
 
     input_names = [

--- a/tests/unit_tests/export/model_adapters/embedding/test_embedding_adapter.py
+++ b/tests/unit_tests/export/model_adapters/embedding/test_embedding_adapter.py
@@ -343,6 +343,33 @@ class TestGetLlamaBidirectionalHFModel:
 
     @patch("nemo_export.model_adapters.embedding.embedding_adapter.AutoTokenizer")
     @patch("nemo_export.model_adapters.embedding.embedding_adapter.AutoModel")
+    def test_get_model_with_attn_implementation(self, mock_auto_model, mock_auto_tokenizer):
+        """Test model loading with a specific attention implementation."""
+        mock_tokenizer = Mock()
+        mock_tokenizer.padding_side = "right"
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        mock_model = Mock()
+        mock_config = Mock()
+        mock_model.config = mock_config
+        mock_model.eval.return_value = mock_model
+        mock_auto_model.from_pretrained.return_value = mock_model
+
+        adapted_model, tokenizer = get_llama_bidirectional_hf_model(
+            model_name_or_path="test/model",
+            normalize=True,
+            attn_implementation="eager",
+        )
+
+        mock_auto_model.from_pretrained.assert_called_once_with(
+            "test/model", torch_dtype=None, trust_remote_code=False, attn_implementation="eager"
+        )
+        assert mock_config._attn_implementation == "eager"
+        assert isinstance(adapted_model, LlamaBidirectionalHFAdapter)
+        assert tokenizer == mock_tokenizer
+
+    @patch("nemo_export.model_adapters.embedding.embedding_adapter.AutoTokenizer")
+    @patch("nemo_export.model_adapters.embedding.embedding_adapter.AutoModel")
     def test_get_model_pooling_mode_adjustment_last(self, mock_auto_model, mock_auto_tokenizer):
         """Test pooling mode adjustment for 'last' with right padding."""
         mock_tokenizer = Mock()


### PR DESCRIPTION
## Summary
- add `attn_implementation` support to the Llama bidirectional embedding adapter factory
- default embedding and reranking ONNX/TensorRT export utilities to `attn_implementation=eager`
- add unit coverage for embedding adapter attention implementation forwarding

## Motivation
Transformers 5.x bidirectional mask creation can fail during TorchScript ONNX tracing in the SDPA masking path. The Nemotron embed recipe avoids the same class of issue by tracing these models with eager attention. This ports that behavior into Export-Deploy’s embedding/reranking export utilities while leaving `sdpa` and `flash_attention_2` available as explicit overrides.

## Validation
- `uv run --no-sync pytest tests/unit_tests/export/model_adapters/embedding/test_embedding_adapter.py tests/unit_tests/export/model_adapters/reranker/test_reranker_adapter.py -q`
- `uv run --no-sync python -m py_compile ...`
- `uv run --no-sync ruff check ...`
- `uv run --no-sync ruff format --check ...`
