### PR TITLE
chore: bump `_code_freeze` workflow to `v1.4.2`

### DIFF
--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -34,7 +34,7 @@ on:
         default: true
 jobs:
   code-freeze:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_code_freeze.yml@v1.4.1
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_code_freeze.yml@v1.4.2
     with:
       library-name: NeMo-Export-Deploy
       python-package: nemo_export_deploy_common

--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -34,7 +34,7 @@ on:
         default: true
 jobs:
   code-freeze:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_code_freeze.yml@v0.86.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_code_freeze.yml@v1.4.1
     with:
       library-name: NeMo-Export-Deploy
       python-package: nemo_export_deploy_common

--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -41,6 +41,8 @@ jobs:
       release-type: ${{ inputs.release-type }}
       freeze-commit: ${{ inputs.freeze-commit }}
       dry-run: ${{ inputs.dry-run }}
+      next-pre-release: ""
+      next-dev: ""
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- Bring this repo's `release-freeze.yml` in line with the rest of the NVIDIA-NeMo/* fleet on the latest tag of the shared `_code_freeze.yml` reusable workflow.
- `v1.4.2` carries the fix that makes the bumped next-version pre-release/dev tags configurable, so a code freeze no longer re-introduces an `rc0` pre-release tag on clean-semver repos (NVIDIA-NeMo/FW-CI-templates#487).

## What changed

- Bump `NVIDIA-NeMo/FW-CI-templates/.github/workflows/_code_freeze.yml` from `v0.86.0` → `v1.4.2`.

## Details

- `.github/workflows/release-freeze.yml:37` — version pin updated.

## Tested

- N/A; manual workflow is exercised on `release-freeze` dispatch.

</details>