### PR TITLE
fix(deploy): pass trust_remote_code to load_tokenizer in in-framework deploy

### DIFF
--- a/nemo_deploy/llm/inference/inference_base.py
+++ b/nemo_deploy/llm/inference/inference_base.py
@@ -265,7 +265,11 @@ def setup_megatron_model_and_tokenizer_for_inference(
         megatron_args=mlm_args,
         use_cpu_init=False,
     )
-    tokenizer = load_tokenizer(checkpoint_path)
+    # In-framework deploy operates on a user-supplied checkpoint that is already trusted
+    # (locally converted and served by the same user), so opt in to the Megatron-Bridge
+    # load_tokenizer security guard that requires trust_remote_code=True when the checkpoint
+    # tokenizer config has it baked in (e.g. Llama tokenizers).
+    tokenizer = load_tokenizer(checkpoint_path, trust_remote_code=True)
     return model, tokenizer, mlm_args
 
 

--- a/tests/unit_tests/deploy/test_inference_base.py
+++ b/tests/unit_tests/deploy/test_inference_base.py
@@ -439,6 +439,43 @@ class TestInferenceBase(unittest.TestCase):
     @patch("nemo_deploy.llm.inference.inference_base.initialize_megatron_for_inference")
     @patch("nemo_deploy.llm.inference.inference_base.build_and_load_model")
     @patch("nemo_deploy.llm.inference.inference_base.load_tokenizer")
+    def test_load_tokenizer_passes_trust_remote_code(
+        self, mock_load_tokenizer, mock_build_model, mock_init_megatron, mock_load_config, mock_torch_dist
+    ):
+        """Regression (NVBug 6393765): load_tokenizer must be called with trust_remote_code=True.
+
+        Megatron-Bridge's load_tokenizer raises ValueError when the checkpoint tokenizer config
+        has trust_remote_code=True baked in (e.g. Llama tokenizers) but the caller does not opt in.
+        The in-framework deploy path must pass trust_remote_code=True so Ray/Triton deployments of
+        converted MBridge checkpoints load the tokenizer instead of failing.
+        """
+        mock_config = MagicMock()
+        mock_config.attention_backend = None
+        mock_config.tensor_model_parallel_size = 1
+        mock_config.pipeline_model_parallel_size = 1
+        mock_config.context_parallel_size = 1
+        mock_config.expert_model_parallel_size = 1
+
+        mock_mlm_args = MagicMock()
+        mock_load_config.return_value = (mock_config, mock_mlm_args)
+
+        mock_build_model.return_value = [MagicMock()]
+        mock_load_tokenizer.return_value = MagicMock()
+
+        setup_megatron_model_and_tokenizer_for_inference(
+            checkpoint_path=self.mock_path,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        )
+
+        # Pre-fix this was load_tokenizer(checkpoint_path) (no kwarg) and the MB guard raised.
+        mock_load_tokenizer.assert_called_once_with(self.mock_path, trust_remote_code=True)
+
+    @patch("nemo_deploy.llm.inference.inference_base.torch_distributed_init")
+    @patch("nemo_deploy.llm.inference.inference_base.load_model_config")
+    @patch("nemo_deploy.llm.inference.inference_base.initialize_megatron_for_inference")
+    @patch("nemo_deploy.llm.inference.inference_base.build_and_load_model")
+    @patch("nemo_deploy.llm.inference.inference_base.load_tokenizer")
     def test_attention_backend_conversion_unfused(
         self, mock_load_tokenizer, mock_build_model, mock_init_megatron, mock_load_config, mock_torch_dist
     ):


### PR DESCRIPTION
Description:

## Summary

Fixes NVBug 6393765: in-framework Ray/Triton deploy crashed in `load_tokenizer()` on container `26.06.01.rc0`. Megatron-Bridge added a guard that raises `ValueError` when a checkpoint's tokenizer_config has `trust_remote_code=True` baked in (e.g. Llama) but the caller doesn't opt in; the in-framework path didn't pass it. Regression vs `26.06.rc9`.

## Changes

- `nemo_deploy/llm/inference/inference_base.py`: pass `trust_remote_code=True` to `load_tokenizer()` in `setup_megatron_model_and_tokenizer_for_inference` (in-framework deploy serves a user-supplied, locally-converted checkpoint that is implicitly trusted).

- `tests/unit_tests/deploy/test_inference_base.py`: new `test_load_tokenizer_passes_trust_remote_code` asserting `load_tokenizer` is called with `trust_remote_code=True`.

## Verifications

- Red-green: FAIL on pre-fix main, PASS after — verified in `nvcr.io/nvidian/nemo:26.02.rc2`.

- e2e on `26.06.01.rc0`: Llama-3.2-1B → MBridge convert → `deploy_ray_inframework.py` serves on `:8000`; `/v1/health` 200 and `/v1/completions` returns a real completion, no ValueError.

## Reference

- NVBug 6393765