### PR TITLE
feat: address new inference updates in mcore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ no-build-isolation-package = [
     "mamba-ssm",
     "causal-conv1d",
     "nv-grouped-gemm",
+    "fast-hadamard-transform",
 ]
 
 # Always apply the build group since dependencies like TE/mcore/nemo-run require build dependencies


### PR DESCRIPTION
Supersedes #706 — carries its commits (Megatron-Core inference API migration + dependency bump) on top of `main`, plus the container-build fix #706 was missing.

## Background / motivation

- #706 migrates in-framework inference to the new Megatron-Core inference API and bumps the Megatron-Bridge rev, but its `cicd-container-build` was red.
- The bumped rev pulls in `megatron-core[dev]` (`v0.19.0+b9f7fb68a`), whose `[dev]` extra now depends on **`fast-hadamard-transform`** — a Dao-AILab CUDA extension that `import torch` in `setup.py`. uv built it under build isolation (torch-less env) → `ModuleNotFoundError: No module named 'torch'`.

## What changed

- **Inference API migration** (from #706): `MCoreEngine` / `GPTInferenceWrapper` / `StaticInferenceContext` / `TextGenerationController` → `MegatronLLM` + `InferenceConfig`; `CommonInferenceParams` → `SamplingParams`; `InferenceRequest` → `DynamicInferenceRequest`. `create_mcore_engine` now returns `(engine, tokenizer)`, always uses the dynamic engine, and derives `block_size_tokens` (64 for MLA, else 256).
- **Dependency bump** (from #706): Megatron-Bridge rev → `97e8dba4…`; `nvidia-resiliency-ext` widened to `<=0.6.0` with matching `dependency-metadata`.
- **Build fix** (new): add `fast-hadamard-transform` to `[tool.uv] no-build-isolation-package`.

## Details

- The earlier `extra-build-dependencies = { fast-hadamard-transform = [...] }` attempt is silently ignored by the CI-pinned uv — `docker/common/install.sh` installs `UV_VERSION="0.7.2"`, which warns `unknown field 'extra-build-dependencies'`. This uses a mechanism 0.7.2 supports.
- `no-build-isolation-package` is the established pattern for torch-at-build-time packages (`transformer-engine`, `mamba-ssm`, `causal-conv1d`, `nv-grouped-gemm`). The build venv is `uv venv --system-site-packages` on the PyTorch NGC base image with `--no-install-package torch`, so torch is present when `fast-hadamard-transform` builds.
- Build-only directive: it doesn't change resolution, and `fast-hadamard-transform` is already pinned in `uv.lock` (git rev `f134af63`) — **no lockfile change needed** (verified with `uv lock --check` → up to date).

## Tested

- Root-caused against the failing `cicd-container-build` logs of #706 (`e67b52cca`) and the prior `8704af9d5` run (which showed the `unknown field` warning + the same torch build error).
- **Reproduced-as-fixed inside the CI base image** (`nvcr.io/nvidian/nemo:export-deploy-pyt-26.04-vllm-v0.20.1`): replicated install.sh's setup (uv 0.7.2, `uv venv --system-site-packages`), then `uv pip install --no-build-isolation` the exact `fast-hadamard-transform` rev `f134af63`:
  ```
  venv sees torch 2.12.0a0+…nv26.04
  Built fast-hadamard-transform @ git+…@f134af63
  IMPORT OK: fast_hadamard_transform
  ```
  No `ModuleNotFoundError` — i.e. exactly what `no-build-isolation-package` triggers during `uv sync`.
- `uv lock --check` → "Resolved 400 packages", lockfile up to date. TOML validated (`tomllib` parse OK).
- Full container build is exercised by `cicd-container-build` on this PR.
