### PR TITLE
fix: use min_output_len value in query_llm inputs

### DIFF
--- a/nemo_deploy/llm/query_llm.py
+++ b/nemo_deploy/llm/query_llm.py
@@ -362,7 +362,7 @@ class NemoQueryLLM(NemoQueryLLMBase):
         inputs = {"prompts": prompts}
 
         if min_output_len is not None:
-            inputs["min_output_len"] = np.full(prompts.shape, max_output_len, dtype=np.int_)
+            inputs["min_output_len"] = np.full(prompts.shape, min_output_len, dtype=np.int_)
 
         if max_output_len is not None:
             inputs["max_output_len"] = np.full(prompts.shape, max_output_len, dtype=np.int_)

--- a/tests/unit_tests/deploy/test_query_llm.py
+++ b/tests/unit_tests/deploy/test_query_llm.py
@@ -501,11 +501,14 @@ class TestNemoQueryLLM:
         mock_instance.infer_batch.return_value = {"outputs": np.array([b"test response"])}
         mock_instance.model_config.outputs = [MagicMock(dtype=np.bytes_)]
 
-        # Test query with min_output_len
+        # Test query with min_output_len distinct from max_output_len
         response = query.query_llm(prompts=["test prompt"], min_output_len=10, max_output_len=100)
 
         assert isinstance(response[0], str)
         assert response[0] == "test response"
+        call_kwargs = mock_instance.infer_batch.call_args.kwargs
+        assert call_kwargs["min_output_len"][0] == 10
+        assert call_kwargs["max_output_len"][0] == 100
 
     @patch("nemo_deploy.llm.query_llm.ModelClient")
     def test_query_llm_with_logits_output(self, mock_client, query):


### PR DESCRIPTION
## Bug

`query_llm` filled the `min_output_len` input with `max_output_len`, so the minimum-length request was ignored and the maximum length was used for both.

## Fix

Use `min_output_len` when building the `min_output_len` input array.

## Test

Updated `TestNemoQueryLLMPyTorch::test_query_llm_with_min_output_len` to verify `min_output_len` and `max_output_len` are passed as distinct values.

## Verification

`ruff check nemo_deploy/llm/query_llm.py tests/unit_tests/deploy/test_query_llm.py` and `ruff format --check ...` pass.

> Note: The Export-Deploy dev environment (uv sync) downloads CUDA/TransformerEngine wheels that overwhelm this laptop, so the full pytest suite could not be run locally. The change is a single-variable substitution and the test follows existing patterns.