### PR TITLE
docs: fix spelling typos across comments, docstrings and messages

### DIFF
--- a/nemo_deploy/llm/inference/tron_utils.py
+++ b/nemo_deploy/llm/inference/tron_utils.py
@@ -261,7 +261,7 @@ def _set_random_seed(
     te_rng_tracker: bool = False,
     inference_rng_tracker: bool = False,
 ) -> None:
-    """Set random seed for reproducability.
+    """Set random seed for reproducibility.
 
     Args:
         seed_ (int): Base random seed to use
@@ -332,7 +332,7 @@ def _initialize_tp_communicators(model_config: Union[GPTConfig, T5Config], micro
             bootstrap_backend=bootstrap_backend,
         )
     except TypeError:
-        # Fallback for older TE versions
+        # Fallback for older Transformer Engine versions
         if bootstrap_backend != "mpi":
             LOGGER.info("Warning: Transformer Engine may only support MPI bootstrap backend")
 

--- a/nemo_deploy/llm/megatronllm_deployable.py
+++ b/nemo_deploy/llm/megatronllm_deployable.py
@@ -69,7 +69,7 @@ class MegatronLLMDeployable(ITritonDeployable):
         context_parallel_size (int): context parallelism.
         expert_model_parallel_size (int): expert parallelism.
         params_dtype (torch.dtype): max input length.
-        inference_batch_times_seqlen_threshold (int): squence threshold.
+        inference_batch_times_seqlen_threshold (int): sequence threshold.
         inference_max_seq_length (int): max_seq_length for inference. Required by MCoreEngine (>=0.12). Defaults to
         4096.
         max_batch_size (int): max batch size for inference. Defaults to 32.
@@ -455,7 +455,7 @@ class MegatronLLMDeployable(ITritonDeployable):
         if log_probs:
             output_log_probs = []
             for r in results:
-                # Convert to torch tensor and then move to cpu as generated_log_probs is a list and cant be moved
+                # Convert to torch tensor and then move to cpu as generated_log_probs is a list and cannot be moved
                 # to cpu otherwise
                 if echo:
                     lp = torch.tensor(r.prompt_log_probs + r.generated_log_probs).cpu().detach().numpy()
@@ -481,7 +481,7 @@ class MegatronLLMDeployable(ITritonDeployable):
         if top_logprobs:
             output_top_n_log_probs = []
             for r in results:
-                # Convert to torch tensor and then move to cpu as generated_log_probs is a list and cant be moved
+                # Convert to torch tensor and then move to cpu as generated_log_probs is a list and cannot be moved
                 # to cpu otherwise.
                 # top_logprobs for input tokens is supported with MCore 0.13 and above.
                 if echo:

--- a/nemo_deploy/service/fastapi_interface_to_pytriton.py
+++ b/nemo_deploy/service/fastapi_interface_to_pytriton.py
@@ -276,7 +276,7 @@ async def chat_completions_v1(request: ChatCompletionRequest):
     prompts = request.messages
     if not isinstance(request.messages, list):
         prompts = [request.messages]
-    # Serialize the dictionary to a JSON string represnetation to be able to convert to numpy array
+    # Serialize the dictionary to a JSON string representation to be able to convert to numpy array
     # (str_list2numpy) and back to list (str_ndarray2list) as required by PyTriton. Using the dictionaries directly
     # with these methods is not possible as they expect string type.
     json_prompts = [dict_to_str(prompts)]

--- a/nemo_deploy/service/fastapi_interface_to_pytriton_multimodal.py
+++ b/nemo_deploy/service/fastapi_interface_to_pytriton_multimodal.py
@@ -298,7 +298,7 @@ async def chat_completions_v1(request: MultimodalChatCompletionRequest):
                 # Remove image_url field
                 content.pop("image_url", None)
 
-    # Serialize the dictionary to a JSON string represnetation to be able to convert to numpy array
+    # Serialize the dictionary to a JSON string representation to be able to convert to numpy array
     # (str_list2numpy) and back to list (str_ndarray2list) as required by PyTriton. Using the dictionaries directly
     # with these methods is not possible as they expect string type.
     json_prompts = [dict_to_str(prompts)]

--- a/nemo_export/model_adapters/embedding/embedding_adapter.py
+++ b/nemo_export/model_adapters/embedding/embedding_adapter.py
@@ -255,7 +255,7 @@ def get_llama_bidirectional_hf_model(
     # configure pooling
     pooling_module = Pooling(pooling_mode=pooling_mode)
 
-    # NV-Embed-v1 model has seperate embedding model and a built-in pooling module
+    # NV-Embed-v1 model has separate embedding model and a built-in pooling module
     if (
         model.__class__.__name__ == "NVEmbedModel"
         and hasattr(model, "latent_attention_model")

--- a/nemo_export/utils/lora_converter.py
+++ b/nemo_export/utils/lora_converter.py
@@ -201,7 +201,7 @@ def convert_lora_nemo_to_canonical(lora_nemo, save_path, hf_format=False, donor_
                         new_key = replace_number_add_offset(key, layer_offset)
                         lora_state_dict[tp][new_key] = value
 
-        # TODO: currently suport tp=1
+        # TODO: currently support tp=1
         lora_state_dict = lora_state_dict[0]
         if lora_config["peft"]["lora_tuning"].get("variant", "nemo") == "nemo":
             lora_config["peft"]["lora_tuning"]["variant"] = "canonical"

--- a/nemo_export/utils/utils.py
+++ b/nemo_export/utils/utils.py
@@ -120,10 +120,10 @@ def get_example_inputs(
 
 
 def validate_fp8_network(network) -> None:
-    """Checks the network to ensure it's compatible with fp8 precison.
+    """Checks the network to ensure it's compatible with fp8 precision.
 
     Raises:
-        ValueError if netowrk doesn't container Q/DQ FP8 layers
+        ValueError if network doesn't container Q/DQ FP8 layers
     """
     import tensorrt as trt
 

--- a/nemo_export_deploy_common/import_utils.py
+++ b/nemo_export_deploy_common/import_utils.py
@@ -394,7 +394,7 @@ def gpu_only_import(module, *, alt=None) -> Tuple[object, bool]:
 
     return safe_import(
         module,
-        msg=f"{module} is not enabled in non GPU-enabled installations or environemnts. {GPU_INSTALL_STRING}",
+        msg=f"{module} is not enabled in non GPU-enabled installations or environments. {GPU_INSTALL_STRING}",
         alt=alt,
     )
 

--- a/tests/functional_tests/utils/run_nemo_export.py
+++ b/tests/functional_tests/utils/run_nemo_export.py
@@ -301,7 +301,7 @@ def run_inference(
 
         functional_result = FunctionalResult()
 
-        # Check non-deployed funcitonal correctness
+        # Check non-deployed functional correctness
         if args.functional_test:
             functional_result.regular_pass = True
             if not check_model_outputs(output, expected_outputs):
@@ -742,7 +742,7 @@ def run_inference_tests(args):
     if args.functional_test:
         print(f"Functional: {functional_test_result}")
     if args.run_accuracy:
-        print(f"Acccuracy: {accuracy_test_result}")
+        print(f"Accuracy: {accuracy_test_result}")
 
     if functional_test_result == "FAIL":
         raise Exception("Functional test failed")

--- a/tests/functional_tests/utils/run_onnx_trt_embedding_export.py
+++ b/tests/functional_tests/utils/run_onnx_trt_embedding_export.py
@@ -179,7 +179,7 @@ def export_onnx_trt(args):
         "/ReduceL2",
         "/Div",
     ]
-    # Model specific operation wheter to override layernorm precision or not.
+    # Model specific operation whether to override layernorm precision or not.
     override_layernorm_precision_to_fp32 = True
     profiling_verbosity = "layer_names_only"
 

--- a/tests/functional_tests/utils/run_onnx_trt_reranking_export.py
+++ b/tests/functional_tests/utils/run_onnx_trt_reranking_export.py
@@ -118,7 +118,7 @@ def export_onnx_trt(args):
         "/model/norm/",
         "/Div",
     ]
-    # Model specific operation wheter to override layernorm precision or not.
+    # Model specific operation whether to override layernorm precision or not.
     override_layernorm_precision_to_fp32 = True
     profiling_verbosity = "layer_names_only"
 

--- a/tests/functional_tests/utils/test_export_onnx.py
+++ b/tests/functional_tests/utils/test_export_onnx.py
@@ -181,7 +181,7 @@ def export_onnx_trt(args):
         "/ReduceL2",
         "/Div",
     ]
-    # Model specific operation wheter to override layernorm precision or not.
+    # Model specific operation whether to override layernorm precision or not.
     override_layernorm_precision_to_fp32 = True
     profiling_verbosity = "layer_names_only"
 


### PR DESCRIPTION
## What

Fixes spelling mistakes surfaced by `codespell` across source comments, docstrings, log messages and test scripts.

## Changes

- `represnetation` → `representation`
- `squence` → `sequence`
- `cant` → `cannot`
- `reproducability` → `reproducibility`
- `TE` → `Transformer Engine`
- `suport` → `support`
- `precison` → `precision`
- `netowrk` → `network`
- `seperate` → `separate`
- `environemnts` → `environments`
- `funcitonal` → `functional`
- `Acccuracy` → `Accuracy`
- `wheter` → `whether`

## Verification

`codespell --skip="uv.lock,*.lock,*.svg,*.ipynb,*.json" nemo_export nemo_deploy nemo_export_deploy_common tests/functional_tests` now reports clean.