### PR TITLE
fix: is_optional input description inverts actual behavior

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: "Test script to execute"
     required: true
   is_optional:
-    description: "Failure will cancel all other tests if set to true"
+    description: "Failure is ignored and other tests continue if set to true"
     required: false
     default: "false"
   is_unit_test:

--- a/unit_tests/github_actions/test_optional_description.py
+++ b/unit_tests/github_actions/test_optional_description.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Regression test: is_optional description matches behavior."""
+
+import sys
+
+
+def main():
+    with open(".github/actions/test-template/action.yml") as f:
+        content = f.read()
+
+    if "Failure will cancel all other tests if set to true" in content:
+        print("BUG: is_optional description inverts the actual behavior")
+        sys.exit(1)
+
+    if "is_optional:" not in content or "description:" not in content:
+        print("Could not find is_optional input description")
+        sys.exit(1)
+
+    print("OK")
+
+


### PR DESCRIPTION
This PR fixes a script issue in `.github/actions/test-template/action.yml`: is_optional input description inverts actual behavior.

## Changes
- `.github/actions/test-template/action.yml`: is_optional input description inverts actual behavior.

## Details
```diff
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -1,1 +1,1 @@
-    description: "Failure will cancel all other tests if set to true"
+    description: "Failure is ignored and other tests continue if set to true"
```

## Tests
- `tests/unit_tests/github_actions/test_optional_description.py`

```diff
--- /dev/null
+++ tests/unit_tests/github_actions/test_optional_description.py
@@ -0,0 +1,21 @@
+#!/usr/bin/env python3
+"""Regression test: is_optional description matches behavior."""
+
+import sys
+
+
+def main():
+    with open(".github/actions/test-template/action.yml") as f:
+        content = f.read()
+
+    if "Failure will cancel all other tests if set to true" in content:
+        print("BUG: is_optional description inverts the actual behavior")
+        sys.exit(1)
+
+    if "is_optional:" not in content or "description:" not in content:
+        print("Could not find is_optional input description")
+        sys.exit(1)
+
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).