### PR TITLE
fix: lockfile workflow cannot push bump branch without PAT

### DIFF
--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ env.TARGET_BRANCH }}
+          token: ${{ secrets.PAT }}
 
       - name: Build container
         env:

--- a/unit_tests/github_actions/test_update_deps_checkout_pat.py
+++ b/unit_tests/github_actions/test_update_deps_checkout_pat.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Regression test: update-lockfile checkout must use PAT to push branch."""
+
+import re
+
+
+def test_update_deps_checkout_pat():
+    with open(".github/workflows/_update_dependencies.yml") as f:
+        content = f.read()
+
+    # Isolate the update-lockfile job (it precedes create-pr)
+    update_job = content.split("  create-pr:")[0]
+
+    match = re.search(
+        r"- name: Checkout repo\s+uses: actions/checkout@[^\n]+\s+with:\s+ref: \$\{\{ env\.TARGET_BRANCH \}\}(?:\s+token: \$\{\{ secrets\.PAT \}\})?",
+        update_job,
+        re.DOTALL,
+    )
+    assert match is not None, "Could not locate update-lockfile checkout step"
+
+    block = match.group(0)
+    assert "token: ${{ secrets.PAT }}" in block, (
+        "BUG: update-lockfile checkout must authenticate with PAT to push the bump branch"
+    )


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/_update_dependencies.yml`: lockfile workflow cannot push bump branch without PAT.

## Changes
- `.github/workflows/_update_dependencies.yml`: lockfile workflow cannot push bump branch without PAT.

## Details
```diff
--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -1,4 +1,5 @@
-      - name: Checkout repo
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: ${{ env.TARGET_BRANCH }}
+      - name: Checkout repo
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
+          token: ${{ secrets.PAT }}
```

## Tests
- `tests/unit_tests/github_actions/test_update_deps_checkout_pat.py`

```diff
--- /dev/null
+++ tests/unit_tests/github_actions/test_update_deps_checkout_pat.py
@@ -0,0 +1,31 @@
+#!/usr/bin/env python3
+"""Regression test: update-lockfile checkout must use PAT to push branch."""
+
+import re
+import sys
+
+
+def main():
+    with open(".github/workflows/_update_dependencies.yml") as f:
+        content = f.read()
+
+    # Isolate the update-lockfile job (it precedes create-pr)
+    update_job = content.split("  create-pr:")[0]
+
+    match = re.search(
+        r"- name: Checkout repo\s+uses: actions/checkout@[^\n]+\s+with:\s+ref: \$\{\{ env\.TARGET_BRANCH \}\}(?:\s+token: \$\{\{ secrets\.PAT \}\})?",
+        update_job,
+        re.DOTALL,
+    )
+    if not match:
+        print("Could not locate update-lockfile checkout step")
+        sys.exit(1)
+
+    block = match.group(0)
+    if "token: ${{ secrets.PAT }}" not in block:
+        print("BUG: update-lockfile checkout must authenticate with PAT to push the bump branch")
+        sys.exit(1)
+
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).