### PR TITLE
fix: e2e jobs use matrix.* without declaring a strategy.matrix

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -184,7 +184,7 @@ jobs:
   cicd-e2e-tests-trt-onnx:
     needs: [pre-flight, cicd-unit-tests-vllm]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}
-    name: ${{ matrix.is_optional && 'PLEASEFIXME_' || '' }}${{ matrix.script }}
+    name: L2_ONNX_TRT
     environment: nemo-ci
     if: |
       (
@@ -202,7 +202,7 @@ jobs:
         uses: ./.github/actions/test-template
         with:
           script: L2_ONNX_TRT
-          is_optional: ${{ matrix.is_optional || false }}
+          is_optional: false
           is_unit_test: "false"
           timeout: 60
           PAT: ${{ secrets.PAT }}
@@ -214,7 +214,7 @@ jobs:
   cicd-e2e-tests-vllm:
     needs: [cicd-unit-tests-vllm, pre-flight]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}
-    name: ${{ matrix.is_optional && 'PLEASEFIXME_' || '' }}${{ matrix.script }}
+    name: L2_Launch_vLLM
     environment: nemo-ci
     if: |
       (
@@ -230,7 +230,7 @@ jobs:
         uses: ./.github/actions/test-template
         with:
           script: L2_Launch_vLLM
-          is_optional: ${{ matrix.is_optional || false }}
+          is_optional: false
           is_unit_test: "false"
           timeout: 60
           PAT: ${{ secrets.PAT }}
@@ -242,7 +242,7 @@ jobs:
   cicd-e2e-tests-inframework:
     needs: [pre-flight, cicd-unit-tests-vllm]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}
-    name: ${{ matrix.is_optional && 'PLEASEFIXME_' || '' }}${{ matrix.script }}
+    name: L2_Launch_InFramework
     environment: nemo-ci
     if: |
       (
@@ -258,7 +258,7 @@ jobs:
         uses: ./.github/actions/test-template
         with:
           script: L2_Launch_InFramework
-          is_optional: ${{ matrix.is_optional || false }}
+          is_optional: false
           is_unit_test: "false"
           timeout: 60
           PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/cicd-main.yml`: e2e jobs use matrix.* without declaring a strategy.matrix.

## Changes
- `.github/workflows/cicd-main.yml`: e2e jobs use matrix.* without declaring a strategy.matrix.

## Details
```diff
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -185,7 +185,7 @@
   cicd-e2e-tests-trt-onnx:
     needs: [pre-flight, cicd-unit-tests-vllm]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}
-    name: ${{ matrix.is_optional && 'PLEASEFIXME_' || '' }}${{ matrix.script }}
+    name: L2_ONNX_TRT
     environment: nemo-ci
     if: |
       (
@@ -202,7 +202,7 @@
       - name: main
         uses: ./.github/actions/test-template
         with:
           script: L2_ONNX_TRT
-          is_optional: ${{ matrix.is_optional || false }}
+          is_optional: false
           is_unit_test: "false"
           timeout: 60
           PAT: ${{ secrets.PAT }}
@@ -215,7 +215,7 @@
   cicd-e2e-tests-vllm:
     needs: [cicd-unit-tests-vllm, pre-flight]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}
-    name: ${{ matrix.is_optional && 'PLEASEFIXME_' || '' }}${{ matrix.script }}
+    name: L2_Launch_vLLM
     environment: nemo-ci
     if: |
       (
@@ -230,7 +230,7 @@
       - name: main
         uses: ./.github/actions/test-template
         with:
           script: L2_Launch_vLLM
-          is_optional: ${{ matrix.is_optional || false }}
+          is_optional: false
           is_unit_test: "false"
           timeout: 60
           PAT: ${{ secrets.PAT }}
@@ -243,7 +243,7 @@
   cicd-e2e-tests-inframework:
     needs: [pre-flight, cicd-unit-tests-vllm]
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}
-    name: ${{ matrix.is_optional && 'PLEASEFIXME_' || '' }}${{ matrix.script }}
+    name: L2_Launch_InFramework
     environment: nemo-ci
     if: |
       (
@@ -258,7 +258,7 @@
       - name: main
         uses: ./.github/actions/test-template
         with:
           script: L2_Launch_InFramework
-          is_optional: ${{ matrix.is_optional || false }}
+          is_optional: false
           is_unit_test: "false"
           timeout: 60
           PAT: ${{ secrets.PAT }}
```

## Tests
- `tests/test_github_workflows.py`

```diff
--- /dev/null
+++ tests/test_github_workflows.py
@@ -0,0 +1,91 @@
+"""Regression tests for GitHub Actions workflows.
+
+These tests use only the Python standard library so they can run without
+installing dependencies.
+"""
+
+import os
+import re
+import unittest
+
+
+WORKFLOWS_DIR = os.path.join(
+    os.path.dirname(__file__), os.pardir, ".github", "workflows"
+)
+
+
+def _read_workflow(name: str) -> str:
+    path = os.path.join(WORKFLOWS_DIR, name)
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _iter_job_blocks(workflow_text: str):
+    """Yield each top-level job definition from a workflow's ``jobs:`` block."""
+    lines = workflow_text.splitlines(keepends=True)
+    in_jobs = False
+    current = None
+    job_start = re.compile(r"^  [A-Za-z0-9_-]+:")
+
+    for line in lines:
+        if not in_jobs:
+            if line.rstrip() == "jobs:":
+                in_jobs = True
+            continue
+
+        if job_start.match(line):
+            if current is not None:
+                yield current
+            current = line
+        elif current is not None:
+            current += line
+
+    if current is not None:
+        yield current
+
+
+class TestWorkflows(unittest.TestCase):
+    def test_hyphenated_matrix_keys_use_bracket_notation(self):
+        """Hyphenated matrix keys must be accessed with bracket syntax."""
+        text = _read_workflow("cicd-main.yml")
+        self.assertNotIn(
+            "matrix.cpu-only",
+            text,
+            "Use matrix['cpu-only'] instead of matrix.cpu-only, which GitHub "
+            "parses as matrix.cpu minus only",
+        )
+
+    def test_jobs_referencing_matrix_declare_strategy(self):
+        """Any job that uses matrix.* must declare a strategy.matrix block."""
+        text = _read_workflow("cicd-main.yml")
+        for block in _iter_job_blocks(text):
+            if "${{ matrix." in block:
+                self.assertIn(
+                    "strategy:",
+                    block,
+                    "Job references matrix but has no strategy block",
+                )
+                self.assertIn(
+                    "matrix:",
+                    block,
+                    "Job strategy block does not define a matrix",
+                )
+
+    def test_copyright_summary_step_has_required_env(self):
+        """The copyright-check summary step must export GH_TOKEN and the skip flag."""
+        text = _read_workflow("copyright-check.yml")
+        idx = text.find("- name: Result")
+        self.assertGreaterEqual(idx, 0, "Result step not found")
+        block = text[idx:]
+
+        self.assertIn("env:", block, "Result step is missing an env block")
+        self.assertIn("GH_TOKEN:", block, "Result step needs GH_TOKEN for gh")
+        self.assertIn(
+            "SKIPPING_IS_ALLOWED:",
+            block,
+            "Result step uses $SKIPPING_IS_ALLOWED but never defines it",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).