### PR TITLE
fix(deploy): resolve inference coordinator host to bindable address

### DIFF
--- a/nemo_deploy/llm/inference/inference_base.py
+++ b/nemo_deploy/llm/inference/inference_base.py
@@ -522,7 +522,13 @@ def create_mcore_engine(
         materialize_only_last_token_logits=True,
     )
 
-    coordinator_host = os.environ.get("MASTER_ADDR")
+    # Fall back to loopback when MASTER_ADDR is unset. Passing None is
+    # indistinguishable from passing nothing, and MCore then binds its data-parallel
+    # inference coordinator to socket.gethostname(), which inside Docker resolves to
+    # the container ID and is not a bindable interface (ZMQError: No such device).
+    # The Ray path never hits this because megatronllm_deployable_ray sets
+    # MASTER_ADDR to the node IP itself; the PyTriton path sets nothing.
+    coordinator_host = os.environ.get("MASTER_ADDR") or "127.0.0.1"
 
     llm = MegatronLLM(
         model=model,

--- a/nemo_deploy/llm/inference/inference_base.py
+++ b/nemo_deploy/llm/inference/inference_base.py
@@ -16,6 +16,7 @@
 import atexit
 import logging
 import os
+import socket
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
@@ -414,6 +415,22 @@ class MCoreEngineWithCleanup:
         return getattr(self.mcore_engine, name)
 
 
+def _default_coordinator_host() -> str:
+    """Return a bindable address for the data-parallel inference coordinator.
+
+    MCore defaults the coordinator host to ``socket.gethostname()``, which is a
+    *name*, not an address. Inside Docker it resolves to the container ID and ZMQ
+    cannot bind it (``ZMQError: No such device``). Resolving that name to its IP
+    yields an address that is both bindable and reachable from other containers,
+    which is what the Ray path already gets by exporting the node IP as
+    ``MASTER_ADDR``. Fall back to loopback only if resolution fails.
+    """
+    try:
+        return socket.gethostbyname(socket.gethostname())
+    except OSError:
+        return "127.0.0.1"
+
+
 def create_mcore_engine(
     path: Path,
     num_devices: Optional[int] = None,
@@ -522,13 +539,7 @@ def create_mcore_engine(
         materialize_only_last_token_logits=True,
     )
 
-    # Fall back to loopback when MASTER_ADDR is unset. Passing None is
-    # indistinguishable from passing nothing, and MCore then binds its data-parallel
-    # inference coordinator to socket.gethostname(), which inside Docker resolves to
-    # the container ID and is not a bindable interface (ZMQError: No such device).
-    # The Ray path never hits this because megatronllm_deployable_ray sets
-    # MASTER_ADDR to the node IP itself; the PyTriton path sets nothing.
-    coordinator_host = os.environ.get("MASTER_ADDR") or "127.0.0.1"
+    coordinator_host = os.environ.get("MASTER_ADDR") or _default_coordinator_host()
 
     llm = MegatronLLM(
         model=model,

--- a/tests/unit_tests/deploy/test_inference_base.py
+++ b/tests/unit_tests/deploy/test_inference_base.py
@@ -829,29 +829,59 @@ class TestInferenceBase(unittest.TestCase):
 
     @patch("nemo_deploy.llm.inference.inference_base.setup_megatron_model_and_tokenizer_for_inference")
     @patch("nemo_deploy.llm.inference.inference_base.MegatronLLM")
-    def test_create_mcore_engine_coordinator_host_defaults_to_loopback(
+    def test_create_mcore_engine_coordinator_host_resolves_to_address(
         self,
         mock_megatron_llm,
         mock_setup,
     ):
-        """coordinator_host must not be None when MASTER_ADDR is unset.
+        """With MASTER_ADDR unset, coordinator_host must be a bindable address.
 
-        MCore falls back to socket.gethostname() when no hostname is supplied, which
-        inside Docker resolves to the container ID and is not a bindable interface
-        (ZMQError: No such device). Only the Ray deployable sets MASTER_ADDR; the
-        PyTriton path sets nothing, so the default has to come from here.
+        MCore defaults the coordinator to socket.gethostname(), which is a name and
+        not an address; inside Docker it is the container ID and ZMQ cannot bind it
+        (ZMQError: No such device). Only the Ray deployable exports MASTER_ADDR, so
+        on the PyTriton path the resolved address has to come from here.
         """
         mock_setup.return_value = ([MagicMock()], MagicMock(), MagicMock())
         mock_megatron_llm.return_value = MagicMock()
 
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("MASTER_ADDR", None)
-            create_mcore_engine(
-                path=self.mock_path,
-                model_format="megatron",
-                inference_max_seq_length=2048,
-                max_batch_size=4,
-            )
+            with patch("nemo_deploy.llm.inference.inference_base.socket") as mock_socket:
+                mock_socket.gethostname.return_value = "9f2c1a4b7d3e"  # container ID
+                mock_socket.gethostbyname.return_value = "172.17.0.2"
+                create_mcore_engine(
+                    path=self.mock_path,
+                    model_format="megatron",
+                    inference_max_seq_length=2048,
+                    max_batch_size=4,
+                )
+
+        host = mock_megatron_llm.call_args.kwargs["coordinator_host"]
+        self.assertEqual(host, "172.17.0.2")
+        self.assertNotEqual(host, "9f2c1a4b7d3e", "must not pass the bare hostname through")
+
+    @patch("nemo_deploy.llm.inference.inference_base.setup_megatron_model_and_tokenizer_for_inference")
+    @patch("nemo_deploy.llm.inference.inference_base.MegatronLLM")
+    def test_create_mcore_engine_coordinator_host_falls_back_when_unresolvable(
+        self,
+        mock_megatron_llm,
+        mock_setup,
+    ):
+        """If the hostname cannot be resolved, fall back to loopback rather than None."""
+        mock_setup.return_value = ([MagicMock()], MagicMock(), MagicMock())
+        mock_megatron_llm.return_value = MagicMock()
+
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("MASTER_ADDR", None)
+            with patch("nemo_deploy.llm.inference.inference_base.socket") as mock_socket:
+                mock_socket.gethostname.return_value = "9f2c1a4b7d3e"
+                mock_socket.gethostbyname.side_effect = OSError("name resolution failed")
+                create_mcore_engine(
+                    path=self.mock_path,
+                    model_format="megatron",
+                    inference_max_seq_length=2048,
+                    max_batch_size=4,
+                )
 
         self.assertEqual(mock_megatron_llm.call_args.kwargs["coordinator_host"], "127.0.0.1")
 

--- a/tests/unit_tests/deploy/test_inference_base.py
+++ b/tests/unit_tests/deploy/test_inference_base.py
@@ -847,7 +847,7 @@ class TestInferenceBase(unittest.TestCase):
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("MASTER_ADDR", None)
             with patch("nemo_deploy.llm.inference.inference_base.socket") as mock_socket:
-                mock_socket.gethostname.return_value = "9f2c1a4b7d3e"  # container ID
+                mock_socket.gethostname.return_value = "test-container-id"  # a name, not an address
                 mock_socket.gethostbyname.return_value = "172.17.0.2"
                 create_mcore_engine(
                     path=self.mock_path,
@@ -858,7 +858,7 @@ class TestInferenceBase(unittest.TestCase):
 
         host = mock_megatron_llm.call_args.kwargs["coordinator_host"]
         self.assertEqual(host, "172.17.0.2")
-        self.assertNotEqual(host, "9f2c1a4b7d3e", "must not pass the bare hostname through")
+        self.assertNotEqual(host, "test-container-id", "must not pass the bare hostname through")
 
     @patch("nemo_deploy.llm.inference.inference_base.setup_megatron_model_and_tokenizer_for_inference")
     @patch("nemo_deploy.llm.inference.inference_base.MegatronLLM")
@@ -874,7 +874,7 @@ class TestInferenceBase(unittest.TestCase):
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("MASTER_ADDR", None)
             with patch("nemo_deploy.llm.inference.inference_base.socket") as mock_socket:
-                mock_socket.gethostname.return_value = "9f2c1a4b7d3e"
+                mock_socket.gethostname.return_value = "test-container-id"
                 mock_socket.gethostbyname.side_effect = OSError("name resolution failed")
                 create_mcore_engine(
                     path=self.mock_path,

--- a/tests/unit_tests/deploy/test_inference_base.py
+++ b/tests/unit_tests/deploy/test_inference_base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import types
 import unittest
 from pathlib import Path
@@ -825,6 +826,55 @@ class TestInferenceBase(unittest.TestCase):
         mock_setup.assert_called_once()
         mock_megatron_llm.assert_called_once()
         self.assertIsNotNone(engine)
+
+    @patch("nemo_deploy.llm.inference.inference_base.setup_megatron_model_and_tokenizer_for_inference")
+    @patch("nemo_deploy.llm.inference.inference_base.MegatronLLM")
+    def test_create_mcore_engine_coordinator_host_defaults_to_loopback(
+        self,
+        mock_megatron_llm,
+        mock_setup,
+    ):
+        """coordinator_host must not be None when MASTER_ADDR is unset.
+
+        MCore falls back to socket.gethostname() when no hostname is supplied, which
+        inside Docker resolves to the container ID and is not a bindable interface
+        (ZMQError: No such device). Only the Ray deployable sets MASTER_ADDR; the
+        PyTriton path sets nothing, so the default has to come from here.
+        """
+        mock_setup.return_value = ([MagicMock()], MagicMock(), MagicMock())
+        mock_megatron_llm.return_value = MagicMock()
+
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("MASTER_ADDR", None)
+            create_mcore_engine(
+                path=self.mock_path,
+                model_format="megatron",
+                inference_max_seq_length=2048,
+                max_batch_size=4,
+            )
+
+        self.assertEqual(mock_megatron_llm.call_args.kwargs["coordinator_host"], "127.0.0.1")
+
+    @patch("nemo_deploy.llm.inference.inference_base.setup_megatron_model_and_tokenizer_for_inference")
+    @patch("nemo_deploy.llm.inference.inference_base.MegatronLLM")
+    def test_create_mcore_engine_coordinator_host_prefers_master_addr(
+        self,
+        mock_megatron_llm,
+        mock_setup,
+    ):
+        """An explicit MASTER_ADDR still wins over the loopback default."""
+        mock_setup.return_value = ([MagicMock()], MagicMock(), MagicMock())
+        mock_megatron_llm.return_value = MagicMock()
+
+        with patch.dict(os.environ, {"MASTER_ADDR": "10.0.0.5"}):
+            create_mcore_engine(
+                path=self.mock_path,
+                model_format="megatron",
+                inference_max_seq_length=2048,
+                max_batch_size=4,
+            )
+
+        self.assertEqual(mock_megatron_llm.call_args.kwargs["coordinator_host"], "10.0.0.5")
 
     @patch("nemo_deploy.llm.inference.inference_base.torch_distributed_init")
     @patch("nemo_deploy.llm.inference.inference_base.load_model_config")


### PR DESCRIPTION
## Summary
  
  Fixes NVBug 6457372: in-framework PyTriton deploys fail on single-node Docker because
  `create_mcore_engine()` passes `os.environ.get("MASTER_ADDR")` (None when unset) as
  `coordinator_host`, so MCore falls back to `socket.gethostname()` — a name, not an address —
  which inside Docker is the container ID and cannot be bound:
  `zmq.error.ZMQError: No such device (addr='tcp://f3879bac406e:*')`. Present since 26.08.rc1
  and still reproducing on 26.08.rc9. The Ray path is unaffected because
  `megatronllm_deployable_ray.py:72` exports the node IP as `MASTER_ADDR` itself; the PyTriton
  deployable exports nothing, so PR #719 added the parameter but no usable default.
  
  ## Changes
  
  - `nemo_deploy/llm/inference/inference_base.py`: add `_default_coordinator_host()`, resolving
    the hostname to its IP and falling back to loopback only if resolution fails; use it when
    `MASTER_ADDR` is unset.
  - `tests/unit_tests/deploy/test_inference_base.py`: three tests asserting the resolved address
    is used and the bare hostname never passed through, that an explicit `MASTER_ADDR` still wins,
    and that unresolvable hostnames fall back to loopback rather than `None`.
  
  ## Verification
  
  - Red-green: bug-sensitive unit test FAILS with the fix reverted, PASSES with it applied —
    verified in `nvcr.io/nvidian/nemo:26.08.rc9`. `ruff check` and `ruff format --check` clean.
  - Bind behaviour measured in `nvcr.io/nvidian/nemo:26.08.rc9`: `socket.gethostname()` →
    `f411026bc80c` (ZMQ bind FAILS); `socket.gethostbyname(gethostname())` → `172.17.0.2`
    (bind OK, routable); `127.0.0.1` (bind OK, not routable).
  - e2e: `test_inframework_mlm_triton` and `test_inframework_mlm_llm_triton` both FAIL on unfixed
    source and both PASS against this branch on `nvcr.io/nvidian/nemo:26.08.rc9`, with
    `MASTER_ADDR` unset and zero ZMQ errors (run 20260812T180350Z-77c29fc6).
  - Control: setting `MASTER_ADDR=127.0.0.1` against unfixed source also turns both green,
    confirming the mechanism independently of the code change.
  
  ## Reference
  
  - NVBug 6457372 
  - Follows up PR #719, which fixed the Ray path