### PR TITLE
fix: inframework e2e job uses matrix context without strategy block

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -269,6 +269,12 @@ jobs:
 
   cicd-e2e-tests-inframework:
     needs: [pre-flight, cicd-unit-tests-vllm]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - script: L2_Launch_InFramework
+            is_optional: false
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}
     name: ${{ matrix.is_optional && 'PLEASEFIXME_' || '' }}${{ matrix.script }}
     environment: nemo-ci

--- a/tests/test_cicd_yaml.py
+++ b/tests/test_cicd_yaml.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_FILE = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "cicd-main.yml"
+
+
+def test_inframework_e2e_job_has_matching_matrix():
+    """Regression test for the inframework e2e job referencing matrix values without a strategy block."""
+    workflow = yaml.safe_load(WORKFLOW_FILE.read_text())
+    job = workflow["jobs"]["cicd-e2e-tests-inframework"]
+
+    assert "strategy" in job, "inframework e2e job must define a strategy block"
+    assert "matrix" in job["strategy"], "strategy block must define a matrix"
+
+    include = job["strategy"]["matrix"].get("include", [])
+    assert len(include) == 1, "expected exactly one matrix include for the inframework e2e job"
+    matrix = include[0]
+    assert matrix["script"] == "L2_Launch_InFramework"
+    assert matrix["is_optional"] is False
+


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/cicd-main.yml`: inframework e2e job uses matrix context without strategy block.

## Changes
- `.github/workflows/cicd-main.yml`: inframework e2e job uses matrix context without strategy block.

## Details
See the Files changed tab for the exact diff.

## Tests
- `tests/test_cicd_yaml.py`

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).